### PR TITLE
[W.I.P] [DO NOT MERGE] feat: add tests for mock ai models for executors

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,49 @@
+import os
+import shutil
+import sys
+import unittest
+from os.path import dirname
+
+import numpy as np
+
+from jina.drivers.helper import array2pb
+from jina.proto import jina_pb2
+
+
+class JinaTestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tmp_files = []
+        os.environ['TEST_WORKDIR'] = os.getcwd()
+
+    def tearDown(self) -> None:
+        for k in self.tmp_files:
+            if os.path.exists(k):
+                if os.path.isfile(k):
+                    os.remove(k)
+                elif os.path.isdir(k):
+                    shutil.rmtree(k, ignore_errors=False, onerror=None)
+
+    def add_tmpfile(self, *path):
+        self.tmp_files.extend(path)
+
+
+file_dir = os.path.dirname(__file__)
+sys.path.append(dirname(file_dir))
+
+
+def random_docs(num_docs, chunks_per_doc=5, embed_dim=10):
+    c_id = 0
+    for j in range(num_docs):
+        d = jina_pb2.Document()
+        d.id = j
+        d.meta_info = b'hello world'
+        d.embedding.CopyFrom(array2pb(np.random.random([embed_dim])))
+        for k in range(chunks_per_doc):
+            c = d.chunks.add()
+            c.text = 'i\'m chunk %d from doc %d' % (c_id, j)
+            c.embedding.CopyFrom(array2pb(np.random.random([embed_dim])))
+            c.id = c_id
+            c.parent_id = j
+            c_id += 1
+        yield d

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,7 @@
+import os
+import sys
+from os.path import dirname
+
+
+file_dir = os.path.dirname(__file__)
+sys.path.append(dirname(file_dir))

--- a/tests/unit/executors/__init__.py
+++ b/tests/unit/executors/__init__.py
@@ -1,0 +1,13 @@
+import os
+
+from jina.executors.metas import get_default_metas
+from tests import JinaTestCase
+
+
+class ExecutorTestCase(JinaTestCase):
+    @property
+    def metas(self):
+        metas = get_default_metas()
+        if 'JINA_TEST_GPU' in os.environ:
+            metas['on_gpu'] = True
+        return metas

--- a/tests/unit/executors/encoders/image/__init__.py
+++ b/tests/unit/executors/encoders/image/__init__.py
@@ -1,0 +1,38 @@
+import os
+import pytest
+import numpy as np
+
+from jina.executors import BaseExecutor
+from tests.unit.executors import ExecutorTestCase
+
+
+class ImageTestCase(ExecutorTestCase):
+    @property
+    def workspace(self):
+        return os.path.join(os.environ['TEST_WORKDIR'], 'test_tmp')
+
+    @property
+    def target_output_dim(self):
+        return self._target_output_dim
+
+    @target_output_dim.setter
+    def target_output_dim(self, output_dim):
+        self._target_output_dim = output_dim
+
+    @property
+    def input_dim(self):
+        return self._input_dim
+
+    @input_dim.setter
+    def input_dim(self, input_dim):
+        self._input_dim = input_dim
+
+    def get_encoder(self):
+        encoder = self._get_encoder(self.metas)
+        if encoder is not None:
+            encoder.workspace = self.workspace
+            self.add_tmpfile(encoder.workspace)
+        return encoder
+
+    def _get_encoder(self, metas):
+        return None

--- a/tests/unit/executors/encoders/image/test_torch_vision.py
+++ b/tests/unit/executors/encoders/image/test_torch_vision.py
@@ -1,0 +1,20 @@
+import pytest
+import numpy as np
+
+from jina.hub.encoders.image.torchvision import ImageTorchEncoder
+from tests.unit.executors.encoders.image import ImageTestCase
+
+
+class TorchVisionTestCase(ImageTestCase):
+    def _get_encoder(self, metas):
+        self.target_output_dim = 1280
+        self.input_dim = 224
+        return ImageTorchEncoder(metas=metas)
+
+    def test_encoding_results(self):
+        encoder = self.get_encoder()
+        if encoder is None:
+            return
+        test_data = np.random.rand(2, 3, self.input_dim, self.input_dim)
+        encoded_data = encoder.encode(test_data)
+        assert encoded_data.shape == (2, self.target_output_dim)


### PR DESCRIPTION
GitHub Issue reference: [Mock AI Models ](https://github.com/jina-ai/jina/issues/824)

- Use input data for testing the *encoding* functionality as an ndarray, eg. B x (Channel x Height x Width)

- Assert the result of encoding against the output data for this encoded data as an ndarray eg. of `B x D` for torchvision.

- This would ensure that the mocking is solely focussed on testing the encoding functionality.

- [ ] Have one unit test per executor model - for all models in image, nlp, etc.
- [ ] Executor test to be dependent on the executor only.
- [ ] Use pytest instead of unittest / mock
- 
