### PR TITLE
refactor(encoders): remove redundant docker instructions

### DIFF
--- a/encoders/image/BigTransferEncoder/Dockerfile
+++ b/encoders/image/BigTransferEncoder/Dockerfile
@@ -8,9 +8,6 @@ WORKDIR /workspace
 RUN apt-get update && apt-get install --no-install-recommends -y git curl && \
     pip install -r requirements.txt
 
-# RUN pip install -r requirements.txt
-COPY . /
-
 # for downloading pre-trained model
 RUN bash download.sh
 

--- a/encoders/image/ImageKerasEncoder/Dockerfile
+++ b/encoders/image/ImageKerasEncoder/Dockerfile
@@ -4,13 +4,10 @@ FROM jinaai/jina
 COPY . /workspace
 WORKDIR /workspace
 
-# install the third-party requirements
-RUN apt-get update && apt-get install --no-install-recommends -y git curl && \
-    pip install -r requirements.txt
-
-COPY . /
+# RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt
 
 # for testing the image
-RUN pip install pytest && pytest -v
+RUN pip install pytest && pytest
 
 ENTRYPOINT ["jina", "pod", "--uses", "config.yml"]

--- a/encoders/image/ImageKerasEncoder/requirements.txt
+++ b/encoders/image/ImageKerasEncoder/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==2.0.1
+tensorflow


### PR DESCRIPTION
Also, should we include `.dockerignore` for the build context?