### PR TITLE
feat: added reverse ranker

### DIFF
--- a/rankers/ReverseRanker/Dockerfile
+++ b/rankers/ReverseRanker/Dockerfile
@@ -1,0 +1,13 @@
+FROM jinaai/jina
+
+# setup the workspace
+COPY . /workspace
+WORKDIR /workspace
+
+# install the third-party requirements
+RUN pip install -r requirements.txt
+
+# for testing the image
+RUN pip install pytest && pytest
+
+ENTRYPOINT ["jina", "pod", "--uses", "config.yml"]

--- a/rankers/ReverseRanker/README.md
+++ b/rankers/ReverseRanker/README.md
@@ -1,0 +1,3 @@
+# ReverseRanker
+
+This ranker returns the inverse of all scores in order to be able to reverse the match order. 

--- a/rankers/ReverseRanker/__init__.py
+++ b/rankers/ReverseRanker/__init__.py
@@ -1,0 +1,25 @@
+import numpy as np
+from typing import Dict
+
+from jina.executors.rankers import Match2DocRanker
+
+
+class ReverseRanker(Match2DocRanker):
+    """
+    :class:`ReverseRanker` This ranker returns the inverse of all scores in
+        order to be able to reverse the match ranking.
+    """
+
+    required_keys = {}
+
+    def score(
+        self, query_meta: Dict, old_match_scores: Dict, match_meta: Dict
+    ) -> "np.ndarray":
+        new_scores = [
+            (
+                match_id,
+                -old_score,
+            )
+            for match_id, old_score in old_match_scores.items()
+        ]
+        return np.array(new_scores, dtype=np.float64)

--- a/rankers/ReverseRanker/config.yml
+++ b/rankers/ReverseRanker/config.yml
@@ -1,0 +1,6 @@
+!ReverseRanker
+with:
+  {}
+metas:
+  py_modules:
+    - __init__.py

--- a/rankers/ReverseRanker/manifest.yml
+++ b/rankers/ReverseRanker/manifest.yml
@@ -1,0 +1,14 @@
+manifest_version: 1
+name: ReverseRanker
+kind: ranker
+description:
+  |
+  This ranker returns the inverse of all scores in order to be able to reverse the match order.
+author: maximilian.werk@jina.ai
+url: https://jina.ai
+vendor: Jina AI Limited
+documentation: https://github.com/jina-ai/jina-hub
+version: 0.0.1
+license: apache-2.0
+keywords: [ranker, reverse]
+type: pod

--- a/rankers/ReverseRanker/requirements.txt
+++ b/rankers/ReverseRanker/requirements.txt
@@ -1,0 +1,2 @@
+git+git://github.com/jina-ai/jina
+

--- a/rankers/ReverseRanker/tests/test_reverseranker.py
+++ b/rankers/ReverseRanker/tests/test_reverseranker.py
@@ -1,0 +1,28 @@
+import copy
+import json
+import numpy as np
+
+from .. import ReverseRanker
+
+
+def test_reverseranker():
+
+    query_meta = {"text": "cool stuff"}
+    query_meta_json = json.dumps(query_meta, sort_keys=True)
+    old_match_scores = {1: 5, 2: 4, 3: 7, 4: -3}
+    old_match_scores_json = json.dumps(old_match_scores, sort_keys=True)
+    match_meta = {1: {"text": "cool stuff"}, 2: {"text": "kewl stuff"}}
+    match_meta_json = json.dumps(match_meta, sort_keys=True)
+
+    ranker = ReverseRanker()
+    new_scores = ranker.score(
+        copy.deepcopy(query_meta),
+        copy.deepcopy(old_match_scores),
+        copy.deepcopy(match_meta)
+    )
+
+    assert (new_scores == np.array([(1, -5), (2, -4), (3, -7), (4, 3)], dtype=np.float64)).all()
+    # Guarantee no side-effects happen
+    assert query_meta_json == json.dumps(query_meta, sort_keys=True)
+    assert old_match_scores_json == json.dumps(old_match_scores, sort_keys=True)
+    assert match_meta_json == json.dumps(match_meta, sort_keys=True)


### PR DESCRIPTION
A ranker that reverses the previous ranking order. As in #406: The build will only work, after a new jina-ai/jina docker image is build, since it uses the Match2DocRanker that was just introduced in the jina-core master.