### PR TITLE
perf: annoy reserves max(idex) + 1 memory, reverse may be more efficient

### DIFF
--- a/indexers/vector/AnnoyIndexer/__init__.py
+++ b/indexers/vector/AnnoyIndexer/__init__.py
@@ -8,6 +8,7 @@ from jina.executors.indexers.vector import BaseNumpyIndexer
 
 
 class AnnoyIndexer(BaseNumpyIndexer):
+
     """Annoy powered vector indexer
 
     For more information about the Annoy supported parameters, please consult:
@@ -36,7 +37,7 @@ class AnnoyIndexer(BaseNumpyIndexer):
     def build_advanced_index(self, vecs: 'np.ndarray'):
         from annoy import AnnoyIndex
         _index = AnnoyIndex(self.num_dim, self.metric)
-        for idx, v in enumerate(vecs):
+        for idx, v in reversed(list(enumerate(vecs))):
             _index.add_item(idx, v.astype(np.float32))
         _index.build(self.n_trees)
         return _index

--- a/indexers/vector/AnnoyIndexer/manifest.yml
+++ b/indexers/vector/AnnoyIndexer/manifest.yml
@@ -3,7 +3,7 @@ name: AnnoyIndexer
 kind: indexer
 type: pod
 description: Annoy powered vector indexer
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
 keywords: [indexer, annoy, ANN]
 author: Jina AI Dev-Team (dev-team@jina.ai)


### PR DESCRIPTION
**Changes introduced**
According to annoy documentation.

```
a.add_item(i, v) adds item i (any nonnegative integer) with vector v. Note that it will allocate memory for max(i)+1 items.
```
so, adding items in reverse order should save calls to `malloc` on Annoy end.