### PR TITLE
Zarr Indexer

### DIFF
--- a/indexers/vector/ZarrIndexer/Dockerfile
+++ b/indexers/vector/ZarrIndexer/Dockerfile
@@ -1,0 +1,13 @@
+FROM jinaai/jina
+
+# setup the workspace
+COPY . /workspace
+WORKDIR /workspace
+
+# install the third-party requirements
+RUN pip install -r requirements.txt
+
+# for testing the image
+RUN pip install pytest && pytest
+
+ENTRYPOINT ["jina", "pod", "--uses", "config.yml"]

--- a/indexers/vector/ZarrIndexer/README.md
+++ b/indexers/vector/ZarrIndexer/README.md
@@ -1,0 +1,3 @@
+# ZarrIndexer
+
+Zarr based indexer 

--- a/indexers/vector/ZarrIndexer/__init__.py
+++ b/indexers/vector/ZarrIndexer/__init__.py
@@ -49,10 +49,8 @@ class ZarrIndexer(NumpyIndexer):
     def get_query_handler(self) -> Optional['zarr.core.Array']:
         if not (path.exists(self.index_abspath) or self.num_dim or self.dtype):
             return
-
-        if hasattr(self, 'write_handler') and 'default' in self.write_handler.array_keys():
-            return zarr.open(store=f'{self.index_abspath}/default', mode='r',
-                             shape=(self._size, self.num_dim), chunks=True)
+        return zarr.open(store=f'{self.index_abspath}/default', mode='r',
+                         shape=(self._size, self.num_dim), chunks=True)
     
     def query_by_id(self, ids: Union[List[int], 'np.ndarray'], *args, **kwargs) -> 'np.ndarray':
         int_ids = [self.ext2int_id[j] for j in ids]

--- a/indexers/vector/ZarrIndexer/__init__.py
+++ b/indexers/vector/ZarrIndexer/__init__.py
@@ -1,0 +1,63 @@
+from os import path
+from typing import List, Union, Optional
+
+import zarr
+import numpy as np
+
+from jina.executors.indexers.vector import NumpyIndexer
+from jina.helper import cached_property
+
+
+class ZarrIndexer(NumpyIndexer):
+    """Indexing based on Zarr arrays
+    
+    For more information about Zarr, please check
+    https://zarr.readthedocs.io/en/stable/index.html
+    
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
+    def get_add_handler(self) -> zarr.hierarchy.Group:
+        """Open an existing zarr group file for adding new vectors
+
+        :return: a zarr group file
+        """
+        return zarr.open(store=self.index_abspath, mode='a')
+
+    def get_create_handler(self) -> zarr.hierarchy.Group:
+        """Create a zarr group file for adding new vectors
+
+        :return: a zarr group file
+        """
+        return zarr.open(store=self.index_abspath, mode='w')
+    
+    def add(self, keys: 'np.ndarray', vectors: 'np.ndarray', *args, **kwargs) -> None:
+        self._validate_key_vector_shapes(keys, vectors)
+        if 'default' in self.write_handler.array_keys():
+            self.write_handler['default'].append(data=vectors)
+        else:
+            self.write_handler.array(name='default', data=vectors)
+        self.key_bytes += keys.tobytes()
+        self.key_dtype = keys.dtype.name
+        self._size += keys.shape[0]
+    
+    @property
+    def query_handler(self):
+        return self.get_query_handler()
+    
+    def get_query_handler(self) -> Optional['zarr.core.Array']:
+        if not (path.exists(self.index_abspath) or self.num_dim or self.dtype):
+            return
+
+        if hasattr(self, 'write_handler') and 'default' in self.write_handler.array_keys():
+            return zarr.open(store=f'{self.index_abspath}/default', mode='r',
+                             shape=(self._size, self.num_dim), chunks=True)
+    
+    def query_by_id(self, ids: Union[List[int], 'np.ndarray'], *args, **kwargs) -> 'np.ndarray':
+        int_ids = [self.ext2int_id[j] for j in ids]
+        return self.raw_ndarray.get_orthogonal_selection(int_ids)
+    
+    @cached_property
+    def raw_ndarray(self):
+        return self.query_handler

--- a/indexers/vector/ZarrIndexer/config.yml
+++ b/indexers/vector/ZarrIndexer/config.yml
@@ -1,0 +1,7 @@
+!ZarrIndexer
+with:
+  {}
+metas:
+  py_modules: 
+    - __init__.py
+    # - You can put more dependencies here

--- a/indexers/vector/ZarrIndexer/manifest.yml
+++ b/indexers/vector/ZarrIndexer/manifest.yml
@@ -1,0 +1,14 @@
+manifest_version: 1
+name: ZarrIndexer
+kind: indexer
+description:
+  |
+  Zarr based indexer
+author: Jina AI Dev-Team (dev-team@jina.ai)
+url: https://jina.ai
+vendor: Jina AI Limited
+documentation: https://github.com/jina-ai/jina-hub
+version: 0.0.1
+license: apache-2.0
+keywords: [zarr, numpy, indexer]
+type: pod

--- a/indexers/vector/ZarrIndexer/requirements.txt
+++ b/indexers/vector/ZarrIndexer/requirements.txt
@@ -1,0 +1,2 @@
+jina
+zarr

--- a/indexers/vector/ZarrIndexer/tests/test_zarrindexer.py
+++ b/indexers/vector/ZarrIndexer/tests/test_zarrindexer.py
@@ -1,0 +1,80 @@
+import os
+import shutil
+
+import zarr
+import numpy as np
+
+from .. import ZarrIndexer
+from jina.executors.indexers import BaseIndexer
+from jina.executors.indexers.vector import NumpyIndexer
+
+np.random.seed(500)
+retr_idx = None
+num_data = 10000
+num_dim = 64
+num_query = 100
+vec_idx = np.arange(num_data)
+np.random.shuffle(vec_idx)
+vec = np.random.random([num_data, num_dim])
+query = np.array(np.random.random([num_query, num_dim]), dtype=np.float32)
+
+
+def rm_files(file_paths):
+    for file_path in file_paths:
+        if os.path.exists(file_path):
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path, ignore_errors=False, onerror=None)
+                
+
+def test_zarr_indexer():
+    rm_files(['test.zarr'])
+    with ZarrIndexer(index_filename='test.zarr') as indexer:
+        indexer.add(vec_idx, vec)
+        indexer.save()
+        assert os.path.exists(indexer.index_abspath)
+        assert indexer.raw_ndarray.shape == vec.shape
+        assert 'default' in indexer.write_handler.array_keys()
+        index_abspath = indexer.index_abspath
+        save_abspath = indexer.save_abspath
+
+    with ZarrIndexer.load(save_abspath) as indexer:
+        assert isinstance(indexer, NumpyIndexer)
+        idx, dist = indexer.query(query, top_k=4)
+        global retr_idx
+        if retr_idx is None:
+            retr_idx = idx
+        else:
+            np.testing.assert_almost_equal(retr_idx, idx)
+        assert idx.shape == dist.shape
+        assert idx.shape == (num_query, 4)
+    rm_files([index_abspath, save_abspath])
+    
+
+def test_zarr_indexer_known():
+    vectors = np.array([[1, 1, 1],
+                        [10, 10, 10],
+                        [100, 100, 100],
+                        [1000, 1000, 1000]])
+    keys = np.array([4, 5, 6, 7]).reshape(-1, 1)
+    with ZarrIndexer(index_filename='test.zarr') as indexer:
+        indexer.add(keys, vectors)
+        indexer.save()
+        assert os.path.exists(indexer.index_abspath)
+        index_abspath = indexer.index_abspath
+        save_abspath = indexer.save_abspath
+
+    queries = np.array([[1, 1, 1],
+                        [10, 10, 10],
+                        [100, 100, 100],
+                        [1000, 1000, 1000]])
+    with ZarrIndexer.load(save_abspath) as indexer:
+        assert isinstance(indexer, NumpyIndexer)
+        idx, dist = indexer.query(queries, top_k=2)
+        np.testing.assert_equal(idx, np.array([[4, 5], [5, 4], [6, 5], [7, 6]]))
+        assert idx.shape == dist.shape
+        assert idx.shape == (4, 2)
+        np.testing.assert_equal(indexer.query_by_id([7, 4]), vectors[[3, 0]])
+
+    rm_files([index_abspath, save_abspath])

--- a/indexers/vector/ZarrIndexer/tests/test_zarrindexer.py
+++ b/indexers/vector/ZarrIndexer/tests/test_zarrindexer.py
@@ -29,7 +29,6 @@ def rm_files(file_paths):
                 
 
 def test_zarr_indexer():
-    rm_files(['test.zarr'])
     with ZarrIndexer(index_filename='test.zarr') as indexer:
         indexer.add(vec_idx, vec)
         indexer.save()


### PR DESCRIPTION
Indexer based on Zarr 

- Inherits `NumpyIndexer`
- `create_handler` & `add_handler` are based on opening a `Zarr Group`, inside which we write a `Zarr Array`
- `query_handler` reads the `Zarr Array`
- Avoid using `[:]` (which gives access to core np array), as that decreases the performance. 
- Memory usage is equivalent to `np.memmap`

Refs :
[Zarr Docs](https://zarr.readthedocs.io/en/stable/index.html)
[Zarr vs Python mmap](https://pythonspeed.com/articles/mmap-vs-zarr-hdf5/)