### PR TITLE
feat: add compression vae executor

### DIFF
--- a/encoders/numeric/CompressionVaeEncoder/Dockerfile
+++ b/encoders/numeric/CompressionVaeEncoder/Dockerfile
@@ -1,0 +1,14 @@
+FROM jinaai/jina
+
+# setup the workspace
+COPY . /workspace
+WORKDIR /workspace
+
+RUN python3 -m pip install --upgrade pip
+# install the third-party requirements
+RUN pip install -r requirements.txt
+
+# for testing the image
+RUN pip install pytest && pytest
+
+ENTRYPOINT ["jina", "pod", "--uses", "config.yml"]

--- a/encoders/numeric/CompressionVaeEncoder/README.md
+++ b/encoders/numeric/CompressionVaeEncoder/README.md
@@ -1,0 +1,3 @@
+# CompressionVaeEncoder
+
+`CompressVaeEncoder` is a dimensionality reduction tool based on the idea of Variational Autoencoders. Full code and documentation can be found here: https://github.com/maxfrenzel/CompressionVAE. 

--- a/encoders/numeric/CompressionVaeEncoder/__init__.py
+++ b/encoders/numeric/CompressionVaeEncoder/__init__.py
@@ -16,13 +16,20 @@ class CompressionVaeEncoder(BaseNumericEncoder, BaseTFEncoder):
     Full code and documentation can be found here: https://github.com/maxfrenzel/CompressionVAE..
     """
 
-    def __init__(self, model_path, train_valid_split=0.99, output_dim=16,
+    def __init__(self, model_path='temp', X=None, train_valid_split=0.99, output_dim=16,
                  iaf_flow_length=10, cells_encoder=[512, 256, 128],
                  initializer='lecun_normal', batch_size=32, batch_size_test=32,
                  feature_normalization=False, tb_logging=False,
                  *args, **kwargs):
         """
         :param model_path: specifies the path to the model, and also acts as the model name.
+        :param X : array, shape (n_samples, n_features)
+            Training data for the VAE.
+            Alternatively, X can be the path to a root-directory containing npy files (potentially nested), each
+            representing a single feature vector. This allows for handling of datasets that are too large to fit
+            in memory.
+            Can be None (default) only if a model with this name has previously been trained. Otherwise None will
+            raise an exception.
         :param train_valid_split: controls the random splitting into train and test data. Here 99% of X is used
         for training, and only 1% is reserved for validation.
         :param dim_latent: specifies the dimensionality of the latent space.
@@ -38,6 +45,7 @@ class CompressionVaeEncoder(BaseNumericEncoder, BaseTFEncoder):
         :param tb_logging: determines whether the model writes summaries for TensorBoard during the training process.
         """
         super().__init__(*args, **kwargs)
+        self.X = X
         self.train_valid_split = train_valid_split
         self.output_dim = output_dim
         self.iaf_flow_length = iaf_flow_length
@@ -61,7 +69,7 @@ class CompressionVaeEncoder(BaseNumericEncoder, BaseTFEncoder):
         :return: a `B x D` numpy ``ndarray``
         """
         from cvae import cvae
-        model = cvae.CompressionVAE(data,
+        model = cvae.CompressionVAE(X=self.X,
                                     train_valid_split=self.train_valid_split,
                                     dim_latent=self.output_dim,
                                     iaf_flow_length=self.iaf_flow_length,
@@ -72,5 +80,4 @@ class CompressionVaeEncoder(BaseNumericEncoder, BaseTFEncoder):
                                     logdir=self.model_path,
                                     feature_normalization=self.feature_normalization,
                                     tb_logging=self.tb_logging)
-
-        return model.train().embed(data)
+        return model.embed(data)

--- a/encoders/numeric/CompressionVaeEncoder/__init__.py
+++ b/encoders/numeric/CompressionVaeEncoder/__init__.py
@@ -1,0 +1,76 @@
+__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__license__ = "Apache-2.0"
+
+import numpy as np
+
+from jina.executors.decorators import batching, as_ndarray
+from jina.executors.encoders import BaseNumericEncoder
+from jina.executors.encoders.frameworks import BaseTFEncoder
+
+
+class CompressionVaeEncoder(BaseNumericEncoder, BaseTFEncoder):
+    """
+    :class:`CompressionVaeEncoder` is a dimensionality reduction tool based on the idea of
+    Variational Autoencoders. It encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`.
+
+    Full code and documentation can be found here: https://github.com/maxfrenzel/CompressionVAE..
+    """
+
+    def __init__(self, model_path, train_valid_split=0.99, output_dim=16,
+                 iaf_flow_length=10, cells_encoder=[512, 256, 128],
+                 initializer='lecun_normal', batch_size=32, batch_size_test=32,
+                 feature_normalization=False, tb_logging=False,
+                 *args, **kwargs):
+        """
+        :param model_path: specifies the path to the model, and also acts as the model name.
+        :param train_valid_split: controls the random splitting into train and test data. Here 99% of X is used
+        for training, and only 1% is reserved for validation.
+        :param dim_latent: specifies the dimensionality of the latent space.
+        :param iaf_flow_length: controls how many IAF(Inverse Autoregressive Flow) flow layers the model has.
+        :param cells_encoder: determines the number, as well as size of the encoders fully connected layers.
+        :param initializer: controls how the model weights are initialized, with options being `orthogonal` (default),
+        `truncated_normal`, and `lecun_normal`
+        :param batch_size: determine the batch sizes used for training.
+        :param batch_size_test: determine the batch sizes used for testing.
+        :param feature_normalization: tells CVAE whether it should internally apply feature normalization
+        (zero mean, unit variance, based on the training data) or not. If True, the normalisation factors are stored
+        with the model and get applied to any future data.
+        :param tb_logging: determines whether the model writes summaries for TensorBoard during the training process.
+        """
+        super().__init__(*args, **kwargs)
+        self.train_valid_split = train_valid_split
+        self.output_dim = output_dim
+        self.iaf_flow_length = iaf_flow_length
+        self.cells_encoder = cells_encoder
+        self.initializer = initializer
+        self.batch_size = batch_size
+        self.batch_size_test = batch_size_test
+        self.model_path = model_path
+        self.feature_normalization = feature_normalization
+        self.tb_logging = tb_logging
+
+    def post_init(self):
+        super().post_init()
+        self.to_device()
+
+    @batching
+    @as_ndarray
+    def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'np.ndarray':
+        """
+        :param data: a `B x T` numpy ``ndarray``, `B` is the size of the batch
+        :return: a `B x D` numpy ``ndarray``
+        """
+        from cvae import cvae
+        model = cvae.CompressionVAE(data,
+                                    train_valid_split=self.train_valid_split,
+                                    dim_latent=self.output_dim,
+                                    iaf_flow_length=self.iaf_flow_length,
+                                    cells_encoder=self.cells_encoder,
+                                    initializer=self.initializer,
+                                    batch_size=self.batch_size,
+                                    batch_size_test=self.batch_size_test,
+                                    logdir=self.model_path,
+                                    feature_normalization=self.feature_normalization,
+                                    tb_logging=self.tb_logging)
+
+        return model.train().embed(data)

--- a/encoders/numeric/CompressionVaeEncoder/config.yml
+++ b/encoders/numeric/CompressionVaeEncoder/config.yml
@@ -1,0 +1,7 @@
+!CompressionVaeEncoder
+with:
+  {}
+metas:
+  py_modules: 
+    - __init__.py
+    # - You can put more dependencies here

--- a/encoders/numeric/CompressionVaeEncoder/manifest.yml
+++ b/encoders/numeric/CompressionVaeEncoder/manifest.yml
@@ -1,0 +1,14 @@
+manifest_version: 1
+name: CompressionVaeEncoder
+kind: encoder
+description:
+  |
+  `CompressVaeEncoder` is a dimensionality reduction tool based on the idea of Variational Autoencoders. It encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`. Full code and documentation can be found here: https://github.com/maxfrenzel/CompressionVAE.
+author: Jina AI Dev-Team (dev-team@jina.ai)
+url: https://jina.ai
+vendor: Jina AI Limited
+documentation: https://github.com/jina-ai/jina-hub
+version: 0.0.1
+license: apache-2.0
+keywords: [Tensorflow,Computer Vision,Variational Autoencoders]
+type: pod

--- a/encoders/numeric/CompressionVaeEncoder/requirements.txt
+++ b/encoders/numeric/CompressionVaeEncoder/requirements.txt
@@ -1,0 +1,2 @@
+jina
+cvae

--- a/encoders/numeric/CompressionVaeEncoder/tests/test_compressionvaeencoder.py
+++ b/encoders/numeric/CompressionVaeEncoder/tests/test_compressionvaeencoder.py
@@ -2,9 +2,10 @@ from .. import CompressionVaeEncoder
 
 import os
 import shutil
-import tempfile
 import numpy as np
 import pytest
+
+from cvae import cvae
 
 from jina.executors import BaseExecutor
 
@@ -42,10 +43,9 @@ def target_output_dim():
 
 
 @pytest.fixture(scope="function")
-def get_encoder(test_data, target_output_dim):
-    from cvae import cvae
-    model_path = tempfile.NamedTemporaryFile().name
-    data_path = tempfile.mkdtemp()
+def get_encoder(tmpdir, test_data, target_output_dim):
+    model_path = str(tmpdir.mkdir('model').join('model'))
+    data_path = str(tmpdir.mkdir('data'))
 
     for idx, features in enumerate(test_data):
         np.save(os.path.join(data_path, str(idx)), features)

--- a/encoders/numeric/CompressionVaeEncoder/tests/test_compressionvaeencoder.py
+++ b/encoders/numeric/CompressionVaeEncoder/tests/test_compressionvaeencoder.py
@@ -1,0 +1,71 @@
+from .. import CompressionVaeEncoder
+
+import os
+import shutil
+import tempfile
+import numpy as np
+import pytest
+
+from jina.executors import BaseExecutor
+
+
+def rm_files(file_paths):
+    for file_path in file_paths:
+        if os.path.exists(file_path):
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path, ignore_errors=False, onerror=None)
+
+
+@pytest.fixture(scope="function")
+def test_data():
+    """
+    Create an array of the given shape and populate it with random samples from a uniform distribution over [0, 1).
+    :return: a `B x T` numpy ``ndarray``, `B` is the size of the batch
+    """
+    batch_size = 10
+    input_dim = 28
+    test_data = np.random.rand(batch_size, input_dim)
+
+    return test_data
+
+
+@pytest.fixture(scope="function")
+def target_output_dim():
+    """
+    The size of the latent space.
+    """
+    target_output_dim = 2
+
+    return target_output_dim
+
+
+def test_encoding_results(test_data, target_output_dim):
+    expected_batch_size = test_data.shape[0]
+
+    path = tempfile.NamedTemporaryFile().name
+
+    encoder = CompressionVaeEncoder(model_path=path, output_dim=target_output_dim)
+    assert encoder is not None
+
+    encoded_data = encoder.encode(test_data)
+    assert encoded_data.shape == (expected_batch_size, target_output_dim)
+    assert type(encoded_data) is np.ndarray
+
+
+def test_save_and_load(test_data, target_output_dim):
+    path = tempfile.NamedTemporaryFile().name
+
+    encoder = CompressionVaeEncoder(model_path=path, output_dim=target_output_dim)
+    assert encoder is not None
+
+    encoded_data_control = encoder.encode(test_data)
+    encoder.touch()
+    encoder.save()
+    assert os.path.exists(encoder.save_abspath)
+
+    encoder_loaded = BaseExecutor.load(encoder.save_abspath)
+    encoded_data_test = encoder_loaded.encode(test_data)
+    np.testing.assert_array_equal(encoded_data_test, encoded_data_control)
+    rm_files([encoder.save_abspath])


### PR DESCRIPTION
# Description
This pull request provides to the user an additional tool to encode data from a ndarray.
**CompressionVAE** is a fast, easy to use, dimensionality reduction tool based on the idea of [Variational Autoencoders](https://www.jeremyjordan.me/variational-autoencoders/). We can consider it an alternative to **t-SNE** and **UMAP**.

* **Pros**:
  * **CompressionVAE** is faster than either **t-SNE** or **UMAP**.
  * **CompressionVAE** learns a deterministic and reversible mapping from data to embedding space.
  * It can be integrated into live systems that can process previously unseen examples without re-training.
  * It can in principle scale to arbitrarily large datasets.
  * **VAEs** have a very strong and well studied theoretical foundation.

* **Cons**:
  * As almost any deep learning tool, it needs a lot of data to be trained. **t-SNE** and **UMAP** work better on small datasets.

# Future work 
The current implementation could be adapted to be used with images, text and videos applying convolutional or recurrent encoders/decoders.

# References
* [Variational autoencoders](https://www.jeremyjordan.me/variational-autoencoders/)
* [CompressionVAE — A Powerful and Versatile Alternative to t-SNE and UMAP](https://towardsdatascience.com/compressionvae-a-powerful-and-versatile-alternative-to-t-sne-and-umap-5c50898b8696)
* [CompressionVAE Full code and documentation](https://github.com/maxfrenzel/CompressionVAE)
