### PR TITLE
feat: proper close

### DIFF
--- a/encoders/image/ImagePaddlehubEncoder/Dockerfile
+++ b/encoders/image/ImagePaddlehubEncoder/Dockerfile
@@ -5,13 +5,13 @@ COPY . /workspace
 WORKDIR /workspace
 
 RUN apt-get update && \
-    apt-get -y install libgomp1 libgl1-mesa-glx libglib2.0-0
+    apt-get -y install libgomp1 libgl1-mesa-glx libglib2.0-0 libsm6 libxext6 libxrender-dev
 
 # install the third-party requirements
 RUN pip install -r requirements.txt && pip uninstall -y pathlib
 
 # for testing the image
-RUN pip install pytest pytest-mock mock && JINA_TEST_PRETRAINED='true' pytest
+RUN pip install pytest && pytest
 
 ENTRYPOINT ["jina", "pod", "--uses", "config.yml"]
 

--- a/encoders/image/ImagePaddlehubEncoder/__init__.py
+++ b/encoders/image/ImagePaddlehubEncoder/__init__.py
@@ -67,6 +67,7 @@ class ImagePaddlehubEncoder(BasePaddleEncoder):
 
     def close(self):
         self.exe.close()
+        super().close()
 
     def get_inputs_and_outputs_name(self, input_dict, output_dict):
         self.inputs_name = input_dict['image'].name

--- a/encoders/image/ImagePaddlehubEncoder/manifest.yml
+++ b/encoders/image/ImagePaddlehubEncoder/manifest.yml
@@ -6,7 +6,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.5
+version: 0.0.6
 license: apache-2.0
 keywords: [Imagenet, PaddleHub, Computer Vision]
 type: pod

--- a/encoders/image/ImagePaddlehubEncoder/tests/test_paddlehub.py
+++ b/encoders/image/ImagePaddlehubEncoder/tests/test_paddlehub.py
@@ -1,11 +1,9 @@
 import os
-import mock
-import shutil
 import numpy as np
 import pytest
-from .. import ImagePaddlehubEncoder
 from jina.executors.metas import get_default_metas
 from jina.executors import BaseExecutor
+from .. import ImagePaddlehubEncoder
 
 input_dim = 224
 target_output_dim = 2048
@@ -14,108 +12,33 @@ test_data = np.random.rand(num_doc, 3, input_dim, input_dim)
 tmp_files = []
 
 
-def teardown():
-    for k in tmp_files:
-        if os.path.exists(k):
-            if os.path.isfile(k):
-                os.remove(k)
-            elif os.path.isdir(k):
-                shutil.rmtree(k, ignore_errors=False, onerror=None)
-
-
-def add_tmpfile(*path):
-    tmp_files.extend(path)
-
-
-def get_encoder():
+@pytest.fixture(scope='function', autouse=True)
+def metas(tmpdir):
     metas = get_default_metas()
     if 'JINA_TEST_GPU' in os.environ:
         metas['on_gpu'] = True
-    return ImagePaddlehubEncoder(metas=metas)
+    metas['workspace'] = str(tmpdir)
+    yield metas
 
 
-class MockModule:
-    def get_embedding(self, texts, *args, **kwargs):
-        return [[np.random.random(target_output_dim), None]] * len(texts)
-
-    def context(self, *args, **kwargs):
-        return {'image': MockTensor('input')}, {'feature_map': MockTensor('output')}, MockModel()
-
-
-class MockTensor:
-    def __init__(self, name):
-        self.name = name
-
-
-class MockModel:
-    pass
-
-
-class MockExecutor:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def close(self):
-        pass
-
-    def run(self, feed, *args, **kwargs):
-        feature_map = np.random.random((num_doc, target_output_dim))
-        return feature_map, None
-
-
-class MockCUDADevice:
-    pass
-
-
-class MockCPUDevice:
-    pass
-
-
-def _test_imagepaddlehubencoder_encode(*args, **kwargs):
-    encoder = get_encoder()
+def test_imagepaddlehubencoder_encode(metas):
+    encoder = ImagePaddlehubEncoder(metas=metas)
     encoded_data = encoder.encode(test_data)
     assert encoded_data.shape == (num_doc, target_output_dim)
-    add_tmpfile(encoder.save_abspath, encoder.config_abspath)
-    teardown()
 
 
-@mock.patch('paddlehub.Module', return_value=MockModule())
-@mock.patch('paddle.fluid.Executor', return_value=MockExecutor())
-@mock.patch('paddle.fluid.CUDAPlace', return_value=MockCUDADevice())
-@mock.patch('paddle.fluid.CPUPlace', return_value=MockCPUDevice())
-def test_imagepaddlehubencoder_encode(*args, **kwargs):
-    _test_imagepaddlehubencoder_encode(*args, **kwargs)
-
-
-@mock.patch('paddlehub.Module', return_value=MockModule())
-@mock.patch('paddle.fluid.Executor', return_value=MockExecutor())
-@mock.patch('paddle.fluid.CUDAPlace', return_value=MockCUDADevice())
-@mock.patch('paddle.fluid.CPUPlace', return_value=MockCPUDevice())
-def test_imagepaddlehubencoder_save_and_load(*args, **kwargs):
-    encoder = get_encoder()
+def test_imagepaddlehubencoder_save_and_load(metas):
+    encoder = ImagePaddlehubEncoder(metas=metas)
     encoder.touch()
     encoder.save()
     assert os.path.exists(encoder.save_abspath)
     encoder_loaded = BaseExecutor.load(encoder.save_abspath)
     assert encoder_loaded.model_name == encoder.model_name
-    add_tmpfile(encoder.save_abspath, encoder.config_abspath)
-    teardown()
 
 
-@mock.patch('paddlehub.Module', return_value=MockModule())
-@mock.patch('paddle.fluid.Executor', return_value=MockExecutor())
-@mock.patch('paddle.fluid.CUDAPlace', return_value=MockCUDADevice())
-@mock.patch('paddle.fluid.CPUPlace', return_value=MockCPUDevice())
-def test_imagepaddlehubencoder_save_and_load_config(*args, **kwargs):
-    encoder = get_encoder()
+def test_imagepaddlehubencoder_save_and_load_config(metas):
+    encoder = ImagePaddlehubEncoder(metas=metas)
     encoder.save_config()
     assert os.path.exists(encoder.config_abspath)
     encoder_loaded = BaseExecutor.load_config(encoder.config_abspath)
     assert encoder_loaded.model_name == encoder.model_name
-    add_tmpfile(encoder.save_abspath, encoder.config_abspath)
-    teardown()
-
-
-@pytest.mark.skipif('JINA_TEST_PRETRAINED' not in os.environ, reason='skip the pretrained test if not set')
-def test_imagepaddlehubencoder_encode_with_pretrained_model():
-    _test_imagepaddlehubencoder_encode()

--- a/encoders/video/VideoPaddleEncoder/Dockerfile
+++ b/encoders/video/VideoPaddleEncoder/Dockerfile
@@ -5,12 +5,12 @@ COPY . /workspace
 WORKDIR /workspace
 
 RUN apt-get update && \
-    apt-get -y install libgomp1 libgl1-mesa-glx libglib2.0-0
+    apt-get -y install libgomp1 libgl1-mesa-glx libglib2.0-0 libsm6 libxext6 libxrender-dev
 
 # install the third-party requirements
 RUN pip install -r requirements.txt && pip uninstall -y pathlib
 
 # for testing the image
-RUN pip install pytest pytest-mock mock && JINA_TEST_PRETRAINED='true' pytest
+RUN pip install pytest && pytest
 
 ENTRYPOINT ["jina", "pod", "--uses", "config.yml"]

--- a/encoders/video/VideoPaddleEncoder/__init__.py
+++ b/encoders/video/VideoPaddleEncoder/__init__.py
@@ -54,6 +54,7 @@ class VideoPaddleEncoder(BasePaddleEncoder):
 
     def close(self):
         self.exe.close()
+        super().close()
 
     @batching
     @as_ndarray

--- a/encoders/video/VideoPaddleEncoder/manifest.yml
+++ b/encoders/video/VideoPaddleEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.6
+version: 0.0.7
 license: apache-2.0
 keywords: [paddlehub, video]
 type: pod

--- a/encoders/video/VideoPaddleEncoder/tests/test_videopaddleencoder.py
+++ b/encoders/video/VideoPaddleEncoder/tests/test_videopaddleencoder.py
@@ -1,12 +1,10 @@
 import os
-import mock
-import shutil
 import numpy as np
 import pytest
 
-from .. import VideoPaddleEncoder
 from jina.executors import BaseExecutor
 from jina.executors.metas import get_default_metas
+from .. import VideoPaddleEncoder
 
 input_dim = 224
 target_output_dim = 2048
@@ -14,106 +12,34 @@ num_doc = 2
 test_data = np.random.rand(num_doc, 3, 3, input_dim, input_dim)
 tmp_files = []
 
-def teardown():
-    for k in tmp_files:
-        if os.path.exists(k):
-            if os.path.isfile(k):
-                os.remove(k)
-            elif os.path.isdir(k):
-                shutil.rmtree(k, ignore_errors=False, onerror=None)
 
-def add_tmpfile(*path):
-    tmp_files.extend(path)
-
-
-def get_encoder():
+@pytest.fixture(scope='function', autouse=True)
+def metas(tmpdir):
     metas = get_default_metas()
+    metas['workspace'] = str(tmpdir)
     if 'JINA_TEST_GPU' in os.environ:
         metas['on_gpu'] = True
-    return VideoPaddleEncoder(metas=metas)
+    return metas
 
 
-class MockModule:
-    def context(self, *args, **kwargs):
-        input_name = MockModel()
-        input_name.name="video"
-        return [input_name], {'feature_map': MockTensor('output')}, MockModel()
-
-
-class MockTensor:
-    def __init__(self, name):
-        self.name = name
-
-
-class MockModel:
-    pass
-
-
-class MockExecutor:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def close(self):
-        pass
-
-    def run(self, feed, *args, **kwargs):
-        feature_map = np.random.random((num_doc, target_output_dim))
-        return feature_map, None
-
-
-class MockCUDADevice:
-    pass
-
-
-class MockCPUDevice:
-    pass
-
-
-def _test_videopaddlehubencoder_encode(*args, **kwargs):
-    encoder = get_encoder()
+def test_videopaddlehubencoder_encode(metas):
+    encoder = VideoPaddleEncoder(metas=metas)
     encoded_data = encoder.encode(test_data)
     assert encoded_data.shape == (num_doc, target_output_dim)
-    add_tmpfile(encoder.save_abspath, encoder.config_abspath)
-    teardown()
 
 
-@mock.patch('paddlehub.Module', return_value=MockModule())
-@mock.patch('paddle.fluid.Executor', return_value=MockExecutor())
-@mock.patch('paddle.fluid.CUDAPlace', return_value=MockCUDADevice())
-@mock.patch('paddle.fluid.CPUPlace', return_value=MockCPUDevice())
-def test_videopaddlehubencoder_encode(*args, **kwargs):
-    _test_videopaddlehubencoder_encode(*args, **kwargs)
-
-
-@mock.patch('paddlehub.Module', return_value=MockModule())
-@mock.patch('paddle.fluid.Executor', return_value=MockExecutor())
-@mock.patch('paddle.fluid.CUDAPlace', return_value=MockCUDADevice())
-@mock.patch('paddle.fluid.CPUPlace', return_value=MockCPUDevice())
-def test_videopaddlehubencoder_save_and_load(*args, **kwargs):
-    encoder = get_encoder()
+def test_videopaddlehubencoder_save_and_load(metas):
+    encoder = VideoPaddleEncoder(metas=metas)
     encoder.touch()
     encoder.save()
     assert os.path.exists(encoder.save_abspath)
     encoder_loaded = BaseExecutor.load(encoder.save_abspath)
     assert encoder_loaded.model_name == encoder.model_name
-    add_tmpfile(encoder.save_abspath, encoder.config_abspath)
-    teardown()
 
 
-@mock.patch('paddlehub.Module', return_value=MockModule())
-@mock.patch('paddle.fluid.Executor', return_value=MockExecutor())
-@mock.patch('paddle.fluid.CUDAPlace', return_value=MockCUDADevice())
-@mock.patch('paddle.fluid.CPUPlace', return_value=MockCPUDevice())
-def test_videopaddlehubencoder_save_and_load_config(*args, **kwargs):
-    encoder = get_encoder()
+def test_videopaddlehubencoder_save_and_load_config(metas):
+    encoder = VideoPaddleEncoder(metas=metas)
     encoder.save_config()
     assert os.path.exists(encoder.config_abspath)
     encoder_loaded = BaseExecutor.load_config(encoder.config_abspath)
     assert encoder_loaded.model_name == encoder.model_name
-    add_tmpfile(encoder.save_abspath, encoder.config_abspath)
-    teardown()
-
-
-@pytest.mark.skipif('JINA_TEST_PRETRAINED' not in os.environ, reason='skip the pretrained test if not set')
-def test_videopaddlehubencoder_encode_with_pretrained_model():
-    _test_videopaddlehubencoder_encode()


### PR DESCRIPTION
Since the addition of FluentdHandler, in the base executor there is a call to properly close the executor `logger`. So all the executors that override the close behavior should ensure that they call the parent close.

Besides this, PaddleHubEncoder was missing some dependencies to work properly