### PR TITLE
fix: rankers are working with tree traversal

### DIFF
--- a/rankers/BM25Ranker/manifest.yml
+++ b/rankers/BM25Ranker/manifest.yml
@@ -13,6 +13,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.5
+version: 0.0.6
 license: apache-2.0
 keywords: [ranker, toyexample, demo]

--- a/rankers/BM25Ranker/tests/test_bm25ranker.py
+++ b/rankers/BM25Ranker/tests/test_bm25ranker.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from jina.executors.rankers import Chunk2DocRanker
+
 from .. import BM25Ranker
 
 
@@ -22,19 +24,29 @@ def create_data():
         query_chunk_meta[query_chunk_id] = {'length': num_query_chunks}
         for c in matches:
             match_chunk_meta[c['id']] = {'length': c['length']}
-            match_idx.append([
+            match_idx.append((
                 c['parent_id'],
                 c['id'],
                 query_chunk_id,
                 c['score'],
-            ])
-    return np.array(match_idx), query_chunk_meta, match_chunk_meta
+            ))
+
+    match_idx_numpy = np.array(
+        match_idx,
+        dtype=[
+            (Chunk2DocRanker.COL_MATCH_PARENT_HASH, np.int64),
+            (Chunk2DocRanker.COL_MATCH_HASH, np.int64),
+            (Chunk2DocRanker.COL_DOC_CHUNK_HASH, np.int64),
+            (Chunk2DocRanker.COL_SCORE, np.float64)
+        ]
+    )
+    return match_idx_numpy, query_chunk_meta, match_chunk_meta
 
 
 def test_ranker():
     ranker = BM25Ranker()
     match_idx, query_chunk_meta, match_chunk_meta = create_data()
-    doc_idx = ranker.score(np.array(match_idx), query_chunk_meta, match_chunk_meta)
+    doc_idx = ranker.score(match_idx, query_chunk_meta, match_chunk_meta)
     # check the matched docs are in descending order of the scores
     assert doc_idx[0][1] > doc_idx[1][1]
     assert doc_idx[0][0] == 1

--- a/rankers/BiMatchRanker/__init__.py
+++ b/rankers/BiMatchRanker/__init__.py
@@ -25,12 +25,12 @@ class BiMatchRanker(Chunk2DocRanker):
         # group by col
         _groups = self._group_by(g, col)
         # take the best match from each group
-        _groups_best = np.stack([gg[gg[:, -1].argsort()][0] for gg in _groups])
+        _groups_best = np.stack([np.sort(gg, order=col)[0] for gg in _groups])
         # doc total length
-        _c = chunk_meta[_groups_best[0, col]]['length']
+        _c = chunk_meta[_groups_best[0][col]]['length']
         # hit chunks
         _h = _groups_best.shape[0]
         # hit distance
-        sum_d_hit = np.sum(_groups_best[:, -1])
+        sum_d_hit = np.sum(_groups_best[self.COL_SCORE])
         # all hit => 0, all_miss => 1
         return 1 - (sum_d_hit + self.D_MISS * (_c - _h)) / (self.D_MISS * _c)

--- a/rankers/BiMatchRanker/manifest.yml
+++ b/rankers/BiMatchRanker/manifest.yml
@@ -6,7 +6,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.5
+version: 0.0.6
 license: apache-2.0
 keywords: [rank, bi-match, naive]
 type: pod

--- a/rankers/BiMatchRanker/tests/test_bimatchranker.py
+++ b/rankers/BiMatchRanker/tests/test_bimatchranker.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from jina.executors.rankers import Chunk2DocRanker
+
 from .. import BiMatchRanker
 
 
@@ -22,19 +24,29 @@ def create_data():
         query_chunk_meta[query_chunk_id] = {'length': num_query_chunks}
         for c in matches:
             match_chunk_meta[c['id']] = {'length': c['length']}
-            match_idx.append([
+            match_idx.append((
                 c['parent_id'],
                 c['id'],
                 query_chunk_id,
                 c['score'],
-            ])
-    return np.array(match_idx), query_chunk_meta, match_chunk_meta
+            ))
+
+    match_idx_numpy = np.array(
+        match_idx,
+        dtype=[
+            (Chunk2DocRanker.COL_MATCH_PARENT_HASH, np.int64),
+            (Chunk2DocRanker.COL_MATCH_HASH, np.int64),
+            (Chunk2DocRanker.COL_DOC_CHUNK_HASH, np.int64),
+            (Chunk2DocRanker.COL_SCORE, np.float64)
+        ]
+    )
+    return match_idx_numpy, query_chunk_meta, match_chunk_meta
 
 
 def test_bimatchranker():
     ranker = BiMatchRanker()
     match_idx, query_chunk_meta, match_chunk_meta = create_data()
-    doc_idx = ranker.score(np.array(match_idx), query_chunk_meta, match_chunk_meta)
+    doc_idx = ranker.score(match_idx, query_chunk_meta, match_chunk_meta)
     # check the matched docs are in descending order of the scores
     assert doc_idx[0][1] > doc_idx[1][1]
     assert doc_idx[1][0] == 4294967294

--- a/rankers/LevenshteinRanker/manifest.yml
+++ b/rankers/LevenshteinRanker/manifest.yml
@@ -8,7 +8,7 @@ author: maximilian.werk@jina.ai
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.2
+version: 0.0.3
 license: apache-2.0
 keywords: [text matching, levenshtein, scorer]
 type: pod

--- a/rankers/LevenshteinRanker/tests/test_levenshteinranker.py
+++ b/rankers/LevenshteinRanker/tests/test_levenshteinranker.py
@@ -2,6 +2,8 @@ import copy
 import json
 import numpy as np
 
+from jina.executors.rankers import Match2DocRanker
+
 from .. import LevenshteinRanker
 
 
@@ -20,7 +22,13 @@ def test_levenshteinranker():
         copy.deepcopy(match_meta)
     )
 
-    np.testing.assert_array_equal(new_scores, [[1, 0], [2, -3]])
+    np.testing.assert_array_equal(
+        new_scores,
+        np.array(
+            [(1, 0), (2, -3)],
+            dtype=[(Match2DocRanker.COL_MATCH_HASH, np.int64), (Match2DocRanker.COL_SCORE, np.float64)],
+        )
+    )
     # Guarantee no side-effects happen
     assert query_meta_json == json.dumps(query_meta, sort_keys=True)
     assert old_match_scores_json == json.dumps(old_match_scores, sort_keys=True)

--- a/rankers/MaxRanker/manifest.yml
+++ b/rankers/MaxRanker/manifest.yml
@@ -9,6 +9,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.5
+version: 0.0.6
 license: apache-2.0
 keywords: [ranker, toyexample, demo]

--- a/rankers/MaxRanker/tests/test_maxranker.py
+++ b/rankers/MaxRanker/tests/test_maxranker.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from jina.executors.rankers import Chunk2DocRanker
+
 from .. import MaxRanker
 
 
@@ -22,19 +24,29 @@ def create_data():
         query_chunk_meta[query_chunk_id] = {'length': num_query_chunks}
         for c in matches:
             match_chunk_meta[c['id']] = {'length': c['length']}
-            match_idx.append([
+            match_idx.append((
                 c['parent_id'],
                 c['id'],
                 query_chunk_id,
                 c['score'],
-            ])
-    return np.array(match_idx), query_chunk_meta, match_chunk_meta
+            ))
+
+    match_idx_numpy = np.array(
+        match_idx,
+        dtype=[
+            (Chunk2DocRanker.COL_MATCH_PARENT_HASH, np.int64),
+            (Chunk2DocRanker.COL_MATCH_HASH, np.int64),
+            (Chunk2DocRanker.COL_DOC_CHUNK_HASH, np.int64),
+            (Chunk2DocRanker.COL_SCORE, np.float64)
+        ]
+    )
+    return match_idx_numpy, query_chunk_meta, match_chunk_meta
 
 
 def test_maxranker():
     ranker = MaxRanker()
     match_idx, query_chunk_meta, match_chunk_meta = create_data()
-    doc_idx = ranker.score(np.array(match_idx), query_chunk_meta, match_chunk_meta)
+    doc_idx = ranker.score(match_idx, query_chunk_meta, match_chunk_meta)
 
     # check the matched docs are in descending order of the scores
     assert doc_idx[0][1] > doc_idx[1][1]

--- a/rankers/MinRanker/manifest.yml
+++ b/rankers/MinRanker/manifest.yml
@@ -9,6 +9,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.5
+version: 0.0.6
 license: apache-2.0
 keywords: [ranker, toyexample, demo]

--- a/rankers/MinRanker/tests/test_minranker.py
+++ b/rankers/MinRanker/tests/test_minranker.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from jina.executors.rankers import Chunk2DocRanker
+
 from .. import MinRanker
 
 
@@ -22,19 +24,29 @@ def create_data():
         query_chunk_meta[query_chunk_id] = {'length': num_query_chunks}
         for c in matches:
             match_chunk_meta[c['id']] = {'length': c['length']}
-            match_idx.append([
+            match_idx.append((
                 c['parent_id'],
                 c['id'],
                 query_chunk_id,
                 c['score'],
-            ])
-    return np.array(match_idx), query_chunk_meta, match_chunk_meta
+            ))
+
+    match_idx_numpy = np.array(
+        match_idx,
+        dtype=[
+            (Chunk2DocRanker.COL_MATCH_PARENT_HASH, np.int64),
+            (Chunk2DocRanker.COL_MATCH_HASH, np.int64),
+            (Chunk2DocRanker.COL_DOC_CHUNK_HASH, np.int64),
+            (Chunk2DocRanker.COL_SCORE, np.float64)
+        ]
+    )
+    return match_idx_numpy, query_chunk_meta, match_chunk_meta
 
 
 def test_minranker():
     ranker = MinRanker()
     match_idx, query_chunk_meta, match_chunk_meta = create_data()
-    doc_idx = ranker.score(np.array(match_idx), query_chunk_meta, match_chunk_meta)
+    doc_idx = ranker.score(match_idx, query_chunk_meta, match_chunk_meta)
     # check the matched docs are in descending order of the scores
     assert doc_idx[0][1] > doc_idx[1][1]
     assert doc_idx[0][0] == 4294967294

--- a/rankers/TfIdfRanker/manifest.yml
+++ b/rankers/TfIdfRanker/manifest.yml
@@ -13,6 +13,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.5
+version: 0.0.6
 license: apache-2.0
 keywords: [ranker, toyexample, demo]


### PR DESCRIPTION
Ranker will work with latest jina version.