### PR TITLE
fix: parameter overwrite enabled again

### DIFF
--- a/encoders/nlp/TransformerTFEncoder/__init__.py
+++ b/encoders/nlp/TransformerTFEncoder/__init__.py
@@ -1,7 +1,6 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from dataclasses import dataclass
 import os
 from typing import Optional
 
@@ -30,21 +29,21 @@ def auto_reduce(model_outputs: 'np.ndarray', mask_2d: 'np.ndarray', model_name: 
     return reduce_cls(model_outputs, mask_2d, cls_pos='tail')
 
 
-@dataclass
-class Transformer:
-    pretrained_model_name_or_path: str = 'bert-base-uncased'
-    pooling_strategy: str = 'auto'
-    max_length: Optional[int] = None
-    truncation_strategy: str = 'longest_first'
-    model_save_path: Optional[str] = None
-
-
-class TransformerTFEncoder(TFDevice, BaseEncoder, Transformer):
+class TransformerTFEncoder(TFDevice, BaseEncoder):
     """
     Internally, TransformerTFEncoder wraps the tensorflow-version of transformers from huggingface.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        pretrained_model_name_or_path: str = 'bert-base-uncased',
+        pooling_strategy: str = 'auto',
+        max_length: Optional[int] = None,
+        truncation_strategy: str = 'longest_first',
+        model_save_path: Optional[str] = None,
+        *args,
+        **kwargs
+    ):
         """
         :param pretrained_model_name_or_path: Either:
             - a string with the `shortcut name` of a pre-trained model to load from cache or download, e.g.: ``bert-base-uncased``.
@@ -67,6 +66,11 @@ class TransformerTFEncoder(TFDevice, BaseEncoder, Transformer):
             `model_save_path` should be relative to executor's workspace
         """
         super().__init__(*args, **kwargs)
+        self.pretrained_model_name_or_path = pretrained_model_name_or_path
+        self.pooling_strategy = pooling_strategy
+        self.max_length = max_length
+        self.truncation_strategy = truncation_strategy
+        self.model_save_path = model_save_path
 
     def __getstate__(self):
         if self.model_save_path:

--- a/encoders/nlp/TransformerTFEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTFEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.6
+version: 0.0.7
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, tensorflow]
 type: pod

--- a/encoders/nlp/TransformerTFEncoder/tests/test_transformertfencoder.py
+++ b/encoders/nlp/TransformerTFEncoder/tests/test_transformertfencoder.py
@@ -1,69 +1,79 @@
 import os
-import shutil
 import numpy as np
 import pytest
+import random
+import string
 from .. import TransformerTFEncoder
 from jina.executors import BaseExecutor
 from jina.executors.metas import get_default_metas
 
 
-def rm_files(tmp_files):
-    for k in tmp_files:
-        if os.path.exists(k):
-            if os.path.isfile(k):
-                os.remove(k)
-            elif os.path.isdir(k):
-                shutil.rmtree(k, ignore_errors=False, onerror=None)
+@pytest.fixture(scope='function')
+def random_workspace_name():
+    """Generate a random workspace name with digits and letters."""
+    rand = ''.join(random.choices(string.ascii_uppercase + string.digits, k=6))
+    return f'JINA_TEST_WORKSPACE_{rand}'
 
 
-os.environ['TEST_WORKDIR'] = os.getcwd()
+@pytest.fixture(scope='function')
+def test_metas(tmpdir, random_workspace_name):
+    os.environ[random_workspace_name] = str(tmpdir)
+    metas = get_default_metas()
+    metas['workspace'] = os.environ[random_workspace_name]
+    if 'JINA_TEST_GPU' in os.environ:
+        metas['on_gpu'] = True
+    yield metas
+    del os.environ[random_workspace_name]
 
-metas = get_default_metas()
-if 'JINA_TEST_GPU' in os.environ:
-    metas['on_gpu'] = True
 
-encoders = [
-    TransformerTFEncoder(
-        pretrained_model_name_or_path='bert-base-uncased',
-        model_save_path='bert-base-uncased',
-        metas=metas),
-    TransformerTFEncoder(
-        pooling_strategy='mean',
-        pretrained_model_name_or_path='bert-base-uncased',
-        model_save_path='bert-base-uncased',
-        metas=metas),
-    TransformerTFEncoder(
-        pooling_strategy='min',
-        pretrained_model_name_or_path='bert-base-uncased',
-        model_save_path='bert-base-uncased',
-        metas=metas),
-    TransformerTFEncoder(
-        pooling_strategy='max',
-        pretrained_model_name_or_path='bert-base-uncased',
-        model_save_path='bert-base-uncased',
-        metas=metas),
-    TransformerTFEncoder(
-        pretrained_model_name_or_path='xlnet-base-cased',
-        model_save_path='xlnet-base-cased',
-        metas=metas),
-    TransformerTFEncoder(
-        pooling_strategy='mean',
-        pretrained_model_name_or_path='xlnet-base-cased',
-        model_save_path='xlnet-base-cased',
-        metas=metas),
-    TransformerTFEncoder(
-        pooling_strategy='min',
-        pretrained_model_name_or_path='xlnet-base-cased',
-        model_save_path='xlnet-base-cased',
-        metas=metas),
-    TransformerTFEncoder(
-        pooling_strategy='max',
-        pretrained_model_name_or_path='xlnet-base-cased',
-        model_save_path='xlnet-base-cased',
-        metas=metas),
+encoders_parameters = [
+    {
+        "pretrained_model_name_or_path": 'bert-base-uncased',
+        "model_save_path": 'bert-base-uncased',
+    },
+    {
+        "pooling_strategy": 'mean',
+        "pretrained_model_name_or_path": 'bert-base-uncased',
+        "model_save_path": 'bert-base-uncased-mean',
+    },
+    {
+        "pooling_strategy": 'min',
+        "pretrained_model_name_or_path": 'bert-base-uncased',
+        "model_save_path": 'bert-base-uncased-min',
+    },
+    {
+        "pooling_strategy": 'max',
+        "pretrained_model_name_or_path": 'bert-base-uncased',
+        "model_save_path": 'bert-base-uncased-max',
+    },
+    {
+        "pretrained_model_name_or_path": 'xlnet-base-cased',
+        "model_save_path": 'xlnet-base-cased',
+    },
+    {
+        "pooling_strategy": 'mean',
+        "pretrained_model_name_or_path": 'xlnet-base-cased',
+        "model_save_path": 'xlnet-base-cased-mean',
+    },
+    {
+        "pooling_strategy": 'min',
+        "pretrained_model_name_or_path": 'xlnet-base-cased',
+        "model_save_path": 'xlnet-base-cased-min',
+    },
+    {
+        "pooling_strategy": 'max',
+        "pretrained_model_name_or_path": 'xlnet-base-cased',
+        "model_save_path": 'xlnet-base-cased-max',
+    }
 ]
 
-@pytest.mark.parametrize('encoder', encoders)
+
+@pytest.fixture
+def encoder(request, test_metas):
+    return TransformerTFEncoder(metas=test_metas, **request.param)
+
+
+@pytest.mark.parametrize('encoder', encoders_parameters[:4], indirect=['encoder'])
 def test_encoding_results(encoder):
     target_output_dim = 768
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
@@ -72,7 +82,7 @@ def test_encoding_results(encoder):
     assert not np.allclose(encoded_data[0], encoded_data[1])
 
 
-@pytest.mark.parametrize('encoder', encoders)
+@pytest.mark.parametrize('encoder', encoders_parameters[:4], indirect=['encoder'])
 def test_save_and_load(encoder):
     encoder.save_config()
     assert os.path.exists(encoder.config_abspath)
@@ -86,13 +96,19 @@ def test_save_and_load(encoder):
     encoded_data_test = encoder_loaded.encode(test_data)
     assert encoder_loaded.max_length == encoder.max_length
     np.testing.assert_array_equal(encoded_data_control, encoded_data_test)
-    rm_files([encoder.config_abspath, encoder.save_abspath, encoder_loaded.config_abspath, encoder_loaded.save_abspath])
 
 
-@pytest.mark.parametrize('encoder', encoders)
+@pytest.mark.parametrize('encoder', encoders_parameters, indirect=['encoder'])
 def test_save_and_load_config(encoder):
     encoder.save_config()
     assert os.path.exists(encoder.config_abspath)
     encoder_loaded = BaseExecutor.load_config(encoder.config_abspath)
     assert encoder_loaded.max_length == encoder.max_length
-    rm_files([encoder_loaded.config_abspath, encoder_loaded.save_abspath])
+
+
+@pytest.mark.parametrize('encoder', encoders_parameters[5:6], indirect=['encoder'])
+def test_parameter_override(encoder):
+    encoder_preset = encoders_parameters[5]
+    assert encoder.pretrained_model_name_or_path == encoder_preset['pretrained_model_name_or_path']
+    assert encoder.pooling_strategy == encoder_preset['pooling_strategy']
+    assert encoder.model_save_path == encoder_preset['model_save_path']

--- a/encoders/nlp/TransformerTorchEncoder/__init__.py
+++ b/encoders/nlp/TransformerTorchEncoder/__init__.py
@@ -1,7 +1,6 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from dataclasses import dataclass
 import os
 from typing import Optional
 
@@ -30,21 +29,21 @@ def auto_reduce(model_outputs: 'np.ndarray', mask_2d: 'np.ndarray', model_name: 
     return reduce_cls(model_outputs, mask_2d, cls_pos='tail')
 
 
-@dataclass
-class Transformer:
-    pretrained_model_name_or_path: str = 'bert-base-uncased'
-    pooling_strategy: str = 'auto'
-    max_length: Optional[int] = None
-    truncation_strategy: str = 'longest_first'
-    model_save_path: Optional[str] = None
-
-
-class TransformerTorchEncoder(TorchDevice, BaseEncoder, Transformer):
+class TransformerTorchEncoder(TorchDevice, BaseEncoder):
     """
     Internally, TransformerTorchEncoder wraps the tensorflow-version of transformers from huggingface.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        pretrained_model_name_or_path: str = 'bert-base-uncased',
+        pooling_strategy: str = 'auto',
+        max_length: Optional[int] = None,
+        truncation_strategy: str = 'longest_first',
+        model_save_path: Optional[str] = None,
+        *args,
+        **kwargs
+    ):
         """
         :param pretrained_model_name_or_path: Either:
             - a string with the `shortcut name` of a pre-trained model to load from cache or download, e.g.: ``bert-base-uncased``.
@@ -66,7 +65,13 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder, Transformer):
         ..warning::
             `model_save_path` should be relative to executor's workspace
         """
+
         super().__init__(*args, **kwargs)
+        self.pretrained_model_name_or_path = pretrained_model_name_or_path
+        self.pooling_strategy = pooling_strategy
+        self.max_length = max_length
+        self.truncation_strategy = truncation_strategy
+        self.model_save_path = model_save_path
 
     def __getstate__(self):
         if self.model_save_path:

--- a/encoders/nlp/TransformerTorchEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTorchEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, pytorch]
 type: pod

--- a/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
+++ b/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
@@ -1,69 +1,79 @@
 import os
-import shutil
 import numpy as np
 import pytest
+import random
+import string
 from .. import TransformerTorchEncoder
 from jina.executors import BaseExecutor
 from jina.executors.metas import get_default_metas
 
 
-def rm_files(tmp_files):
-    for k in tmp_files:
-        if os.path.exists(k):
-            if os.path.isfile(k):
-                os.remove(k)
-            elif os.path.isdir(k):
-                shutil.rmtree(k, ignore_errors=False, onerror=None)
+@pytest.fixture(scope='function')
+def random_workspace_name():
+    """Generate a random workspace name with digits and letters."""
+    rand = ''.join(random.choices(string.ascii_uppercase + string.digits, k=6))
+    return f'JINA_TEST_WORKSPACE_{rand}'
 
 
-os.environ['TEST_WORKDIR'] = os.getcwd()
+@pytest.fixture(scope='function')
+def test_metas(tmpdir, random_workspace_name):
+    os.environ[random_workspace_name] = str(tmpdir)
+    metas = get_default_metas()
+    metas['workspace'] = os.environ[random_workspace_name]
+    if 'JINA_TEST_GPU' in os.environ:
+        metas['on_gpu'] = True
+    yield metas
+    del os.environ[random_workspace_name]
 
-metas = get_default_metas()
-if 'JINA_TEST_GPU' in os.environ:
-    metas['on_gpu'] = True
 
-encoders = [
-    TransformerTorchEncoder(
-        pretrained_model_name_or_path='bert-base-uncased',
-        model_save_path='bert-base-uncased',
-        metas=metas),
-    TransformerTorchEncoder(
-        pooling_strategy='mean',
-        pretrained_model_name_or_path='bert-base-uncased',
-        model_save_path='bert-base-uncased-mean',
-        metas=metas),
-    TransformerTorchEncoder(
-        pooling_strategy='min',
-        pretrained_model_name_or_path='bert-base-uncased',
-        model_save_path='bert-base-uncased-min',
-        metas=metas),
-    TransformerTorchEncoder(
-        pooling_strategy='max',
-        pretrained_model_name_or_path='bert-base-uncased',
-        model_save_path='bert-base-uncased-max',
-        metas=metas),
-    TransformerTorchEncoder(
-        pretrained_model_name_or_path='xlnet-base-cased',
-        model_save_path='xlnet-base-cased',
-        metas=metas),
-    TransformerTorchEncoder(
-        pooling_strategy='mean',
-        pretrained_model_name_or_path='xlnet-base-cased',
-        model_save_path='xlnet-base-cased-mean',
-        metas=metas),
-    TransformerTorchEncoder(
-        pooling_strategy='min',
-        pretrained_model_name_or_path='xlnet-base-cased',
-        model_save_path='xlnet-base-cased-min',
-        metas=metas),
-    TransformerTorchEncoder(
-        pooling_strategy='max',
-        pretrained_model_name_or_path='xlnet-base-cased',
-        model_save_path='xlnet-base-cased-max',
-        metas=metas),
+encoders_parameters = [
+    {
+        "pretrained_model_name_or_path": 'bert-base-uncased',
+        "model_save_path": 'bert-base-uncased',
+    },
+    {
+        "pooling_strategy": 'mean',
+        "pretrained_model_name_or_path": 'bert-base-uncased',
+        "model_save_path": 'bert-base-uncased-mean',
+    },
+    {
+        "pooling_strategy": 'min',
+        "pretrained_model_name_or_path": 'bert-base-uncased',
+        "model_save_path": 'bert-base-uncased-min',
+    },
+    {
+        "pooling_strategy": 'max',
+        "pretrained_model_name_or_path": 'bert-base-uncased',
+        "model_save_path": 'bert-base-uncased-max',
+    },
+    {
+        "pretrained_model_name_or_path": 'xlnet-base-cased',
+        "model_save_path": 'xlnet-base-cased',
+    },
+    {
+        "pooling_strategy": 'mean',
+        "pretrained_model_name_or_path": 'xlnet-base-cased',
+        "model_save_path": 'xlnet-base-cased-mean',
+    },
+    {
+        "pooling_strategy": 'min',
+        "pretrained_model_name_or_path": 'xlnet-base-cased',
+        "model_save_path": 'xlnet-base-cased-min',
+    },
+    {
+        "pooling_strategy": 'max',
+        "pretrained_model_name_or_path": 'xlnet-base-cased',
+        "model_save_path": 'xlnet-base-cased-max',
+    }
 ]
 
-@pytest.mark.parametrize('encoder', encoders)
+
+@pytest.fixture
+def encoder(request, test_metas):
+    return TransformerTorchEncoder(metas=test_metas, **request.param)
+
+
+@pytest.mark.parametrize('encoder', encoders_parameters, indirect=['encoder'])
 def test_encoding_results(encoder):
     target_output_dim = 768
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
@@ -71,7 +81,8 @@ def test_encoding_results(encoder):
     assert encoded_data.shape == (2, target_output_dim)
     assert not np.allclose(encoded_data[0], encoded_data[1])
 
-@pytest.mark.parametrize('encoder', encoders)
+
+@pytest.mark.parametrize('encoder', encoders_parameters, indirect=['encoder'])
 def test_save_and_load(encoder):
     encoder.save_config()
     assert os.path.exists(encoder.config_abspath)
@@ -84,13 +95,19 @@ def test_save_and_load(encoder):
     encoded_data_test = encoder_loaded.encode(test_data)
     assert encoder_loaded.max_length == encoder.max_length
     np.testing.assert_array_equal(encoded_data_control, encoded_data_test)
-    rm_files([encoder.config_abspath, encoder.save_abspath, encoder_loaded.config_abspath, encoder_loaded.save_abspath])
 
 
-@pytest.mark.parametrize('encoder', encoders)
+@pytest.mark.parametrize('encoder', encoders_parameters, indirect=['encoder'])
 def test_save_and_load_config(encoder):
     encoder.save_config()
     assert os.path.exists(encoder.config_abspath)
     encoder_loaded = BaseExecutor.load_config(encoder.config_abspath)
     assert encoder_loaded.max_length == encoder.max_length
-    rm_files([encoder_loaded.config_abspath, encoder_loaded.save_abspath])
+
+
+@pytest.mark.parametrize('encoder', encoders_parameters[5:6], indirect=['encoder'])
+def test_parameter_override(encoder):
+    encoder_preset = encoders_parameters[5]
+    assert encoder.pretrained_model_name_or_path == encoder_preset['pretrained_model_name_or_path']
+    assert encoder.pooling_strategy == encoder_preset['pooling_strategy']
+    assert encoder.model_save_path == encoder_preset['model_save_path']


### PR DESCRIPTION
This is a revert from some time ago. Alternative solution would be:
```
def __init__(self, *args, **kwargs):
    super().init(self, *args, **kwargs)
    Transformer(self, *args, **kwargs)
```

Multiclass inheritance is not always working as one would expect.