### PR TITLE
fix: load model in post_init

### DIFF
--- a/encoders/numeric/CompressionVaeEncoder/__init__.py
+++ b/encoders/numeric/CompressionVaeEncoder/__init__.py
@@ -58,7 +58,18 @@ class CompressionVaeEncoder(BaseNumericEncoder, BaseTFEncoder):
         self.tb_logging = tb_logging
 
     def post_init(self):
-        super().post_init()
+        from cvae import cvae
+        self.model = cvae.CompressionVAE(X=self.X,
+                                         train_valid_split=self.train_valid_split,
+                                         dim_latent=self.output_dim,
+                                         iaf_flow_length=self.iaf_flow_length,
+                                         cells_encoder=self.cells_encoder,
+                                         initializer=self.initializer,
+                                         batch_size=self.batch_size,
+                                         batch_size_test=self.batch_size_test,
+                                         logdir=self.model_path,
+                                         feature_normalization=self.feature_normalization,
+                                         tb_logging=self.tb_logging)
         self.to_device()
 
     @batching
@@ -68,16 +79,4 @@ class CompressionVaeEncoder(BaseNumericEncoder, BaseTFEncoder):
         :param data: a `B x T` numpy ``ndarray``, `B` is the size of the batch
         :return: a `B x D` numpy ``ndarray``
         """
-        from cvae import cvae
-        model = cvae.CompressionVAE(X=self.X,
-                                    train_valid_split=self.train_valid_split,
-                                    dim_latent=self.output_dim,
-                                    iaf_flow_length=self.iaf_flow_length,
-                                    cells_encoder=self.cells_encoder,
-                                    initializer=self.initializer,
-                                    batch_size=self.batch_size,
-                                    batch_size_test=self.batch_size_test,
-                                    logdir=self.model_path,
-                                    feature_normalization=self.feature_normalization,
-                                    tb_logging=self.tb_logging)
-        return model.embed(data)
+        return self.model.embed(data)

--- a/encoders/numeric/CompressionVaeEncoder/__init__.py
+++ b/encoders/numeric/CompressionVaeEncoder/__init__.py
@@ -16,60 +16,23 @@ class CompressionVaeEncoder(BaseNumericEncoder, BaseTFEncoder):
     Full code and documentation can be found here: https://github.com/maxfrenzel/CompressionVAE..
     """
 
-    def __init__(self, model_path='temp', X=None, train_valid_split=0.99, output_dim=16,
-                 iaf_flow_length=10, cells_encoder=[512, 256, 128],
-                 initializer='lecun_normal', batch_size=32, batch_size_test=32,
-                 feature_normalization=False, tb_logging=False,
+    def __init__(self, model_path='temp',
                  *args, **kwargs):
         """
-        :param model_path: specifies the path to the model, and also acts as the model name.
-        :param X : array, shape (n_samples, n_features)
-            Training data for the VAE.
-            Alternatively, X can be the path to a root-directory containing npy files (potentially nested), each
-            representing a single feature vector. This allows for handling of datasets that are too large to fit
-            in memory.
-            Can be None (default) only if a model with this name has previously been trained. Otherwise None will
-            raise an exception.
-        :param train_valid_split: controls the random splitting into train and test data. Here 99% of X is used
-        for training, and only 1% is reserved for validation.
-        :param dim_latent: specifies the dimensionality of the latent space.
-        :param iaf_flow_length: controls how many IAF(Inverse Autoregressive Flow) flow layers the model has.
-        :param cells_encoder: determines the number, as well as size of the encoders fully connected layers.
-        :param initializer: controls how the model weights are initialized, with options being `orthogonal` (default),
-        `truncated_normal`, and `lecun_normal`
-        :param batch_size: determine the batch sizes used for training.
-        :param batch_size_test: determine the batch sizes used for testing.
-        :param feature_normalization: tells CVAE whether it should internally apply feature normalization
-        (zero mean, unit variance, based on the training data) or not. If True, the normalisation factors are stored
-        with the model and get applied to any future data.
-        :param tb_logging: determines whether the model writes summaries for TensorBoard during the training process.
+        :param model_path: specifies the path to the pretrained model
+
         """
         super().__init__(*args, **kwargs)
-        self.X = X
-        self.train_valid_split = train_valid_split
-        self.output_dim = output_dim
-        self.iaf_flow_length = iaf_flow_length
-        self.cells_encoder = cells_encoder
-        self.initializer = initializer
-        self.batch_size = batch_size
-        self.batch_size_test = batch_size_test
         self.model_path = model_path
-        self.feature_normalization = feature_normalization
-        self.tb_logging = tb_logging
 
     def post_init(self):
         from cvae import cvae
-        self.model = cvae.CompressionVAE(X=self.X,
-                                         train_valid_split=self.train_valid_split,
-                                         dim_latent=self.output_dim,
-                                         iaf_flow_length=self.iaf_flow_length,
-                                         cells_encoder=self.cells_encoder,
-                                         initializer=self.initializer,
-                                         batch_size=self.batch_size,
-                                         batch_size_test=self.batch_size_test,
-                                         logdir=self.model_path,
-                                         feature_normalization=self.feature_normalization,
-                                         tb_logging=self.tb_logging)
+        import tensorflow as tf
+        config = tf.ConfigProto(log_device_placement=False)
+        config.gpu_options.allow_growth = True
+        with tf.Session(config=config) as sess:
+            saver = tf.train.Saver(var_list=tf.trainable_variables(), max_to_keep=2)
+            self.model = cvae.load(saver, sess, self.model_path)
         self.to_device()
 
     @batching

--- a/encoders/numeric/CompressionVaeEncoder/manifest.yml
+++ b/encoders/numeric/CompressionVaeEncoder/manifest.yml
@@ -8,7 +8,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.1
+version: 0.0.2
 license: apache-2.0
 keywords: [Tensorflow,Computer Vision,Variational Autoencoders]
 type: pod

--- a/encoders/numeric/CompressionVaeEncoder/tests/test_compressionvaeencoder.py
+++ b/encoders/numeric/CompressionVaeEncoder/tests/test_compressionvaeencoder.py
@@ -37,7 +37,7 @@ def get_encoder(metadata, test_data):
                                 logdir=model_path)
     model.train()
 
-    return CompressionVaeEncoder(model_path=model_path, X=data_path, output_dim=target_output_dim, metas=metadata)
+    return CompressionVaeEncoder(model_path=model_path, metas=metadata)
 
 
 @pytest.fixture(scope="function")

--- a/encoders/numeric/CompressionVaeEncoder/tests/test_compressionvaeencoder.py
+++ b/encoders/numeric/CompressionVaeEncoder/tests/test_compressionvaeencoder.py
@@ -1,22 +1,43 @@
-from .. import CompressionVaeEncoder
-
 import os
-import shutil
 import numpy as np
 import pytest
 
 from cvae import cvae
 
 from jina.executors import BaseExecutor
+from jina.executors.metas import get_default_metas
+
+from .. import CompressionVaeEncoder
+
+target_output_dim = 2
 
 
-def rm_files(file_paths):
-    for file_path in file_paths:
-        if os.path.exists(file_path):
-            if os.path.isfile(file_path):
-                os.remove(file_path)
-            elif os.path.isdir(file_path):
-                shutil.rmtree(file_path, ignore_errors=False, onerror=None)
+@pytest.fixture(scope='function', autouse=True)
+def metas(tmpdir):
+    os.environ['TEST_WORKSPACE'] = str(tmpdir)
+    metas = get_default_metas()
+    metas['workspace'] = os.environ['TEST_WORKSPACE']
+    yield metas
+    del os.environ['TEST_WORKSPACE']
+
+
+def get_encoder(metadata, test_data):
+    tmpdir = metadata['workspace']
+    model_path = os.path.join(tmpdir, 'model')
+    data_path = os.path.join(tmpdir, 'data')
+    os.mkdir(model_path)
+    os.mkdir(data_path)
+
+    for idx, features in enumerate(test_data):
+        np.save(os.path.join(data_path, str(idx)), features)
+
+    # Train the CVAE on the test data to build a model saved in `logdir`.
+    model = cvae.CompressionVAE(data_path,
+                                dim_latent=target_output_dim,
+                                logdir=model_path)
+    model.train()
+
+    return CompressionVaeEncoder(model_path=model_path, X=data_path, output_dim=target_output_dim, metas=metadata)
 
 
 @pytest.fixture(scope="function")
@@ -32,48 +53,16 @@ def test_data():
     return test_data
 
 
-@pytest.fixture(scope="function")
-def target_output_dim():
-    """
-    The size of the latent space.
-    """
-    target_output_dim = 2
-
-    return target_output_dim
-
-
-@pytest.fixture(scope="function")
-def get_encoder(tmpdir, test_data, target_output_dim):
-    model_path = str(tmpdir.mkdir('model').join('model'))
-    data_path = str(tmpdir.mkdir('data'))
-
-    for idx, features in enumerate(test_data):
-        np.save(os.path.join(data_path, str(idx)), features)
-
-    # Train the CVAE on the test data to build a model saved in `logdir`.
-    model = cvae.CompressionVAE(data_path,
-                                dim_latent=target_output_dim,
-                                logdir=model_path)
-    model.train()
-
-    return CompressionVaeEncoder(model_path=model_path, X=data_path, output_dim=target_output_dim)
-
-
-def test_encoding_results(get_encoder, test_data, target_output_dim):
+def test_encoding_results(metas, test_data):
     expected_batch_size = test_data.shape[0]
-
-    encoder = get_encoder
-    assert encoder is not None
-
+    encoder = get_encoder(metas, test_data)
     encoded_data = encoder.encode(test_data)
     assert encoded_data.shape == (expected_batch_size, target_output_dim)
     assert type(encoded_data) is np.ndarray
 
 
-def test_save_and_load(get_encoder, test_data):
-    encoder = get_encoder
-    assert encoder is not None
-
+def test_save_and_load(metas, test_data):
+    encoder = get_encoder(metas, test_data)
     encoded_data_control = encoder.encode(test_data)
     encoder.touch()
     encoder.save()
@@ -82,12 +71,3 @@ def test_save_and_load(get_encoder, test_data):
     encoder_loaded = BaseExecutor.load(encoder.save_abspath)
     encoded_data_test = encoder_loaded.encode(test_data)
     np.testing.assert_array_equal(encoded_data_test, encoded_data_control)
-    rm_files([encoder.save_abspath])
-
-
-def test_save_and_load_config(get_encoder):
-    encoder = get_encoder
-    encoder.save_config()
-    assert os.path.exists(encoder.config_abspath)
-    encoder_loaded = BaseExecutor.load_config(encoder.config_abspath)
-    assert encoder_loaded.model_path == encoder.model_path


### PR DESCRIPTION
Hey @umbertogriffo,

I realized a problem at least with `cvae 0.0.3`.

- First, from jina perspective , we can't instantiate a model at every batch, therefore the model loading should be done at `post_init` time.

- Second, when initializing model, it removes the `logdir`, so I do not understand how it is working for the current version (because I also see they raise an exception about X not being of the right type (the check of X being None is commented out).

Could you point what is the direction to have to load a pretrained model from a path (currently jina executor should not care for now about `training` params).
