### PR TITLE
test: add advanced tests to nmslib indexer

### DIFF
--- a/indexers/vector/NmsLibIndexer/manifest.yml
+++ b/indexers/vector/NmsLibIndexer/manifest.yml
@@ -7,6 +7,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
 keywords: [indexer, vector, ann, nmslib]

--- a/indexers/vector/NmsLibIndexer/tests/test_nmslibindexer.py
+++ b/indexers/vector/NmsLibIndexer/tests/test_nmslibindexer.py
@@ -1,69 +1,110 @@
 import os
-import shutil
+import pytest
 
 import numpy as np
 from jina.executors.indexers import BaseIndexer
 from jina.executors.indexers.vector import NumpyIndexer
+from jina.executors.metas import get_default_metas
 
 from .. import NmsLibIndexer
 
 # fix the seed here
 np.random.seed(500)
-retr_idx = None
 vec_idx = np.random.randint(0, high=100, size=[10])
 vec = np.random.random([10, 10])
 query = np.array(np.random.random([10, 10]), dtype=np.float32)
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-def rm_files(file_paths):
-    for file_path in file_paths:
-        if os.path.exists(file_path):
-            if os.path.isfile(file_path):
-                os.remove(file_path)
-            elif os.path.isdir(file_path):
-                shutil.rmtree(file_path, ignore_errors=False, onerror=None)
+@pytest.fixture(scope='function', autouse=True)
+def metas(tmpdir):
+    os.environ['TEST_WORKSPACE'] = str(tmpdir)
+    metas = get_default_metas()
+    metas['workspace'] = os.environ['TEST_WORKSPACE']
+    yield metas
+    del os.environ['TEST_WORKSPACE']
 
 
-def test_nmslib_indexer():
-    with NmsLibIndexer(index_filename='np.test.gz', space='l2') as indexer:
+def test_nmslib_indexer(metas):
+    with NmsLibIndexer(index_filename='np.test.gz', space='l2', metas=metas) as indexer:
         indexer.add(vec_idx, vec)
         indexer.save()
         assert os.path.exists(indexer.index_abspath)
-        index_abspath = indexer.index_abspath
         save_abspath = indexer.save_abspath
 
-    with BaseIndexer.load(indexer.save_abspath) as indexer:
+    with BaseIndexer.load(save_abspath) as indexer:
         assert isinstance(indexer, NmsLibIndexer)
         idx, dist = indexer.query(query, top_k=4)
-        global retr_idx
-        if retr_idx is None:
-            retr_idx = idx
-        else:
-            np.testing.assert_almost_equal(retr_idx, idx)
         assert idx.shape == dist.shape
         assert idx.shape == (10, 4)
 
-    rm_files([index_abspath, save_abspath])
 
-
-def test_nmslib_wrap_indexer():
-    with NumpyIndexer(index_filename='wrap-npidx.gz') as indexer:
+def test_nmslib_wrap_indexer(metas):
+    with NumpyIndexer(index_filename='wrap-npidx.gz', metas=metas) as indexer:
         indexer.name = 'wrap-npidx'
         indexer.add(vec_idx, vec)
         indexer.save()
-        index_abspath = indexer.index_abspath
-        save_abspath = indexer.save_abspath
 
     with BaseIndexer.load_config(os.path.join(cur_dir, 'yaml/nmslib-wrap.yml')) as indexer:
         assert isinstance(indexer, NmsLibIndexer)
         idx, dist = indexer.query(query, top_k=4)
-        global retr_idx
-        if retr_idx is None:
-            retr_idx = idx
-        else:
-            np.testing.assert_almost_equal(retr_idx, idx)
         assert idx.shape == dist.shape
         assert idx.shape == (10, 4)
 
-    rm_files([index_abspath, save_abspath])
+
+def test_nmslib_indexer_known(metas):
+    vectors = np.array([[1, 1, 1],
+                        [10, 10, 10],
+                        [100, 100, 100],
+                        [1000, 1000, 1000]], dtype=np.float32)
+    keys = np.array([4, 5, 6, 7]).reshape(-1, 1)
+    with NmsLibIndexer(space='l2', index_filename='nmslib.test.gz', metas=metas) as indexer:
+        indexer.add(keys, vectors)
+        indexer.save()
+        assert os.path.exists(indexer.index_abspath)
+        save_abspath = indexer.save_abspath
+
+    queries = np.array([[1, 1, 1],
+                        [10, 10, 10],
+                        [100, 100, 100],
+                        [1000, 1000, 1000]], dtype=np.float32)
+    with BaseIndexer.load(save_abspath) as indexer:
+        assert isinstance(indexer, NmsLibIndexer)
+        idx, dist = indexer.query(queries, top_k=2)
+        np.testing.assert_equal(idx, np.array([[4, 5], [5, 4], [6, 5], [7, 6]]))
+        assert idx.shape == dist.shape
+        assert idx.shape == (4, 2)
+        np.testing.assert_equal(indexer.query_by_id([7, 4]), vectors[[3, 0]])
+
+
+def test_nmslib_indexer_known_big(metas):
+
+    """Let's try to have some real test. We will have an index with 10k vectors of random values between 5 and 10.
+     We will change tweak some specific vectors that we expect to be retrieved at query time. We will tweak vector
+     at index [0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000], this will also be the query vectors.
+     Then the keys will be assigned shifted to test the proper usage of `int2ext_id` and `ext2int_id`
+    """
+    vectors = np.random.uniform(low=5.0, high=10.0, size=(10000, 1024)).astype('float32')
+
+    queries = np.empty((10, 1024), dtype=np.float32)
+    for idx in range(0, 10000, 1000):
+        array = idx * np.ones((1, 1024), dtype=np.float32)
+        queries[int(idx / 1000)] = array
+        vectors[idx] = array
+
+    keys = np.arange(10000, 20000).reshape(-1, 1)
+
+    with NmsLibIndexer(space='l2', method='brute_force', index_filename='nmslib.test.gz', num_threads=4, metas=metas) as indexer:
+        indexer.add(keys, vectors)
+        indexer.save()
+        assert os.path.exists(indexer.index_abspath)
+        save_abspath = indexer.save_abspath
+
+    with BaseIndexer.load(save_abspath) as indexer:
+        assert isinstance(indexer, NmsLibIndexer)
+        idx, dist = indexer.query(queries, top_k=1)
+        np.testing.assert_equal(idx, np.array(
+            [[10000], [11000], [12000], [13000], [14000], [15000], [16000], [17000], [18000], [19000]]))
+        assert idx.shape == dist.shape
+        assert idx.shape == (10, 1)
+        np.testing.assert_equal(indexer.query_by_id([10000, 15000]), vectors[[0, 5000]])

--- a/indexers/vector/NmsLibIndexer/tests/yaml/nmslib-wrap.yml
+++ b/indexers/vector/NmsLibIndexer/tests/yaml/nmslib-wrap.yml
@@ -4,6 +4,7 @@ with:
     !NumpyIndexer
     metas:
       name: wrap-npidx
+      workspace: $TEST_WORKSPACE
     with:
       backend: numpy
       compress_level: 1


### PR DESCRIPTION
**Changes introduced**
NmsLib addBatch function assigns indexes to the vectors from 0 ... dataset_length per batch, therefore when doing `batching` need to take into account and return the ordered indexes to assign indexes to the vectors in the index.

Depends on https://github.com/jina-ai/jina/pull/1089