### PR TITLE
feat(image_reader): allow to read numpy images

### DIFF
--- a/crafters/image/ImageReader/__init__.py
+++ b/crafters/image/ImageReader/__init__.py
@@ -11,12 +11,12 @@ class ImageReader(BaseCrafter):
     shape (h,w,depth).
     """
 
-    def __init__(self, color_channel_axis: int = -1, *args, **kwargs):
+    def __init__(self, channel_axis: int = -1, *args, **kwargs):
         """
-        :param color_channel_axis: the axis id of the color channel -1 indicates the color channel info at the last axis
+        :param channel_axis: the axis id of the color channel -1 indicates the color channel info at the last axis
         """
         super().__init__(*args, **kwargs)
-        self.channel_axis = color_channel_axis
+        self.channel_axis = channel_axis
 
     def craft(self, buffer: bytes, uri: str, blob: 'np.ndarray', *args, **kwargs) -> Dict:
         """

--- a/crafters/image/ImageReader/__init__.py
+++ b/crafters/image/ImageReader/__init__.py
@@ -7,36 +7,50 @@ from jina.executors.crafters import BaseCrafter
 
 class ImageReader(BaseCrafter):
     """
-    :class:`ImageReader` loads the image from the given file path and save the `ndarray` of the image in the Document.
+    :class:`ImageReader` loads the image from the given file path, bytes or ndarray, and emits the unified `ndarray` with
+    shape (h,w,depth).
     """
 
-    def __init__(self, channel_axis: int = -1, *args, **kwargs):
+    def __init__(self, color_channel_axis: int = -1, *args, **kwargs):
         """
-        :class:`ImageReader` load an image file and craft into image matrix.
-
-        :param channel_axis: the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
+        :param color_channel_axis: the axis id of the color channel -1 indicates the color channel info at the last axis
         """
         super().__init__(*args, **kwargs)
-        self.channel_axis = channel_axis
+        self.channel_axis = color_channel_axis
 
-    def craft(self, buffer: bytes, uri: str, *args, **kwargs) -> Dict:
+    def craft(self, buffer: bytes, uri: str, blob: 'np.ndarray', *args, **kwargs) -> Dict:
         """
-        Read the image from the given file path that specified in `buffer` and save the `ndarray` of the image in
-            the `blob` of the document.
+        Read the image from the given `buffer`, `uri` or `blob` and saves the unified `ndarray` of the image in
+        the `blob` of the document.
 
-        :param buffer: the image in raw bytes
+        :param buffer: the encoded image in raw bytes (png, jpg)
         :param uri: the image file path
-
+        :param blob: the image as ndarray
         """
+
+        pil_image = self.get_pil_image(buffer, uri, blob)
+        pil_image = pil_image.convert('RGB')
+        numpy_image = np.array(pil_image).astype('float32')
+        if self.channel_axis != -1:
+            numpy_image = np.moveaxis(numpy_image, -1, self.channel_axis)
+        return dict(weight=1., blob=numpy_image)
+
+    def validate_nd_image(self, nd_image):
+        if nd_image.dtype != np.uint8:
+            raise TypeError(f'ndarray has dtype {nd_image.dtype}, required {np.uint8}')
+        shape_len = len(nd_image.shape)
+        if not 2 <= shape_len <= 3:
+            raise ValueError(f'image shape has x={shape_len} dimensions and violates 2 <= x <= 3')
+
+    def get_pil_image(self, buffer, uri, blob):
         from PIL import Image
         if buffer:
-            raw_img = Image.open(io.BytesIO(buffer))
+            pil_image = Image.open(io.BytesIO(buffer))
         elif uri:
-            raw_img = Image.open(uri)
+            pil_image = Image.open(uri)
+        elif blob is not None:
+            self.validate_nd_image(blob)
+            pil_image = Image.fromarray(blob)
         else:
-            raise ValueError('no value found in "buffer" and "uri"')
-        raw_img = raw_img.convert('RGB')
-        img = np.array(raw_img).astype('float32')
-        if self.channel_axis != -1:
-            img = np.moveaxis(img, -1, self.channel_axis)
-        return dict(weight=1., blob=img)
+            raise ValueError('no value found in "buffer", "uri" and "blob"')
+        return pil_image

--- a/crafters/image/ImageReader/tests/test_imagereader.py
+++ b/crafters/image/ImageReader/tests/test_imagereader.py
@@ -20,9 +20,9 @@ def create_test_image(filename, size_width, size_height):
         image.save(f, 'jpeg')
 
 
-def test_io_uri():
+def test_io_uri(tmpdir):
     crafter = ImageReader()
-    filename = os.path.join(crafter.current_workspace, 'test.jpeg')
+    filename = os.path.join(tmpdir, 'test.jpeg')
     img_h = 20
     img_w = 30
     create_test_image(filename, size_width=img_w, size_height=img_h)

--- a/crafters/image/ImageReader/tests/test_imagereader.py
+++ b/crafters/image/ImageReader/tests/test_imagereader.py
@@ -3,35 +3,95 @@ import os
 
 import numpy as np
 from PIL import Image
+import pytest
 
 from .. import ImageReader
 
 
-def create_test_image(output_fn, size_width=50, size_height=50):
+def create_pil_image(size_width, size_height):
     from PIL import Image
-    image = Image.new('RGB', size=(size_width, size_height), color=(155, 0, 0))
-    with open(output_fn, "wb") as f:
+    image = Image.new('RGB', size=(size_width, size_height), color=(50, 100, 150))
+    return image
+
+
+def create_test_image(filename, size_width, size_height):
+    image = create_pil_image(size_width, size_height)
+    with open(filename, "wb") as f:
         image.save(f, 'jpeg')
 
 
 def test_io_uri():
     crafter = ImageReader()
-    tmp_fn = os.path.join(crafter.current_workspace, 'test.jpeg')
-    img_size = 50
-    create_test_image(tmp_fn, size_width=img_size, size_height=img_size)
-    test_doc = crafter.craft(buffer=None, uri=tmp_fn)
-    assert test_doc['blob'].shape == (img_size, img_size, 3)
+    filename = os.path.join(crafter.current_workspace, 'test.jpeg')
+    img_h = 20
+    img_w = 30
+    create_test_image(filename, size_width=img_w, size_height=img_h)
+    test_doc = crafter.craft(buffer=None, uri=filename, blob=None)
+    assert test_doc['blob'].shape == (img_h, img_w, 3)
 
 
 def test_io_buffer():
     crafter = ImageReader()
-    tmp_fn = os.path.join(crafter.current_workspace, 'test.jpeg')
-    img_size = 50
-    create_test_image(tmp_fn, size_width=img_size, size_height=img_size)
+    filename = os.path.join(crafter.current_workspace, 'test.jpeg')
+    img_h = 20
+    img_w = 30
+    create_test_image(filename, size_width=img_w, size_height=img_h)
     image_buffer = io.BytesIO()
-    img = Image.open(tmp_fn)
+    img = Image.open(filename)
     img.save(image_buffer, format='PNG')
     image_buffer.seek(0)
-    test_doc = crafter.craft(buffer=image_buffer.getvalue(), uri=None)
-    assert test_doc['blob'].shape == (img_size, img_size, 3)
+    test_doc = crafter.craft(buffer=image_buffer.getvalue(), uri=None, blob=None)
+    assert test_doc['blob'].shape == (img_h, img_w, 3)
     np.testing.assert_almost_equal(test_doc['blob'], np.array(img).astype('float32'))
+
+
+def test_io_blob():
+    crafter = ImageReader()
+    img_h = 20
+    img_w = 30
+    numpy_image = np.random.randint(0, 255, size=(img_h, img_w, 3), dtype=np.uint8)
+    test_doc = crafter.craft(buffer=None, uri=None, blob=numpy_image)
+    assert test_doc['blob'].shape == (img_h, img_w, 3)
+
+
+def test_blob_no_color_channel():
+    crafter = ImageReader()
+    img_h = 20
+    img_w = 30
+    numpy_image = np.random.randint(0, 255, size=(img_h, img_w), dtype=np.uint8)
+    test_doc = crafter.craft(buffer=None, uri=None, blob=numpy_image)
+    assert test_doc['blob'].shape == (img_h, img_w, 3)
+
+
+def test_blob_alpha_channel():
+    crafter = ImageReader()
+    img_h = 20
+    img_w = 30
+    numpy_image = np.random.randint(0, 255, size=(img_h, img_w, 4), dtype=np.uint8)
+    test_doc = crafter.craft(buffer=None, uri=None, blob=numpy_image)
+    assert test_doc['blob'].shape == (img_h, img_w, 3)
+
+
+def test_blob_incorrect_dtype():
+    crafter = ImageReader()
+    numpy_image = np.random.rand(10, 20, 3)
+    with pytest.raises(TypeError):
+        crafter.craft(buffer=None, uri=None, blob=numpy_image)
+
+
+def test_blob_color_dim_first():
+    crafter = ImageReader(color_channel_axis=0)
+    img_h = 20
+    img_w = 30
+    numpy_image = np.random.randint(0, 255, size=(img_h, img_w, 3), dtype=np.uint8)
+    test_doc = crafter.craft(buffer=None, uri=None, blob=numpy_image)
+    assert test_doc['blob'].shape == (3, img_h, img_w)
+
+
+def test_blob_preserve_color_channels():
+    crafter = ImageReader()
+    img_h = 20
+    img_w = 30
+    numpy_image = np.repeat([np.repeat(np.array([[50, 100, 150]], dtype=np.uint8), img_w, axis=0)], img_h, axis=0)
+    test_doc = crafter.craft(buffer=None, uri=None, blob=numpy_image)
+    assert np.array_equal(test_doc['blob'][0, 0], [50, 100, 150])

--- a/crafters/image/ImageReader/tests/test_imagereader.py
+++ b/crafters/image/ImageReader/tests/test_imagereader.py
@@ -80,7 +80,7 @@ def test_blob_incorrect_dtype():
 
 
 def test_blob_color_dim_first():
-    crafter = ImageReader(color_channel_axis=0)
+    crafter = ImageReader(channel_axis=0)
     img_h = 20
     img_w = 30
     numpy_image = np.random.randint(0, 255, size=(img_h, img_w, 3), dtype=np.uint8)


### PR DESCRIPTION
- ndarray can be used as input for ImageReader
- ndarray without color dimensions can be used
- if there is an alpha channel, it will be converted to rgb
- raises exception in case the input array type is not uint8
- raises exception in case it has an incorrect shape
- unit tests added