### PR TITLE
bumping version for TikaExtractor to 0.0.3 (new jina: 0.7.11)

### DIFF
--- a/crafters/nlp/TikaExtractor/manifest.yml
+++ b/crafters/nlp/TikaExtractor/manifest.yml
@@ -6,7 +6,8 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.2
+version: 0.0.3
 license: apache-2.0
 keywords: [nlp]
 type: pod
+jina-version: 0.7.11


### PR DESCRIPTION
Due to the release of jina core v0.7.11, this PR is automatically submitted to ensure compatibility 