### PR TITLE
chore: testing/building SlidingWindowSegmenter (0.0.6) on new jina core: 0.8.0

### DIFF
--- a/crafters/nlp/SlidingWindowSegmenter/manifest.yml
+++ b/crafters/nlp/SlidingWindowSegmenter/manifest.yml
@@ -11,3 +11,4 @@ version: 0.0.6
 license: apache-2.0
 keywords: [Some keywords to describe the executor, separated by commas]
 jina_version: 0.7.11
+timestamp: 1606135755.9966717


### PR DESCRIPTION
Due to the release of jina core v0.8.0, this draft PR is created in order to trigger an automatic build & push of the module 