### PR TITLE
fix: update transformer encoders for v4 of transformers library

### DIFF
--- a/encoders/nlp/TransformerTFEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTFEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, tensorflow]
 type: pod

--- a/encoders/nlp/TransformerTFEncoder/requirements.txt
+++ b/encoders/nlp/TransformerTFEncoder/requirements.txt
@@ -1,5 +1,5 @@
 jina
-transformers==3.0.0
-tensorflow_cpu==2.1.0
+transformers>=3.0.2
+tensorflow-cpu>=2.1.0
 protobuf>=3.9.2
 grpcio>=1.24.3

--- a/encoders/nlp/TransformerTFEncoder/tests/test_transformertfencoder.py
+++ b/encoders/nlp/TransformerTFEncoder/tests/test_transformertfencoder.py
@@ -124,4 +124,4 @@ def test_max_length(test_metas):
     test_data = np.array(['it is a very good day!', 'it is a very sunny day!'])
     encoded_data = encoder.encode(test_data)
 
-    numpy.testing.assert_allclose(encoded_data[0], encoded_data[1])
+    np.testing.assert_allclose(encoded_data[0], encoded_data[1])

--- a/encoders/nlp/TransformerTFEncoder/tests/test_transformertfencoder.py
+++ b/encoders/nlp/TransformerTFEncoder/tests/test_transformertfencoder.py
@@ -64,7 +64,13 @@ encoders_parameters = [
         "pooling_strategy": 'max',
         "pretrained_model_name_or_path": 'xlnet-base-cased',
         "model_save_path": 'xlnet-base-cased-max',
-    }
+    },
+    {
+        "pooling_strategy": 'mean',
+        "pretrained_model_name_or_path": 'distilbert-base-cased',
+        "model_save_path": 'distilbert-base-cased-mean',
+        "max_length": 100
+    },
 ]
 
 

--- a/encoders/nlp/TransformerTFEncoder/tests/test_transformertfencoder.py
+++ b/encoders/nlp/TransformerTFEncoder/tests/test_transformertfencoder.py
@@ -118,3 +118,10 @@ def test_parameter_override(encoder):
     assert encoder.pretrained_model_name_or_path == encoder_preset['pretrained_model_name_or_path']
     assert encoder.pooling_strategy == encoder_preset['pooling_strategy']
     assert encoder.model_save_path == encoder_preset['model_save_path']
+
+def test_max_length(test_metas):
+    encoder = TransformerTFEncoder(metas=test_metas, max_length=3)
+    test_data = np.array(['it is a very good day!', 'it is a very sunny day!'])
+    encoded_data = encoder.encode(test_data)
+
+    numpy.testing.assert_allclose(encoded_data[0], encoded_data[1])

--- a/encoders/nlp/TransformerTorchEncoder/__init__.py
+++ b/encoders/nlp/TransformerTorchEncoder/__init__.py
@@ -73,6 +73,8 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
         self.truncation_strategy = truncation_strategy
         self.model_save_path = model_save_path
 
+        self._padding_strategy = 'max_length' if self.max_length else 'longest'
+
     def __getstate__(self):
         if self.model_save_path:
             if not os.path.exists(self.model_abspath):
@@ -131,15 +133,15 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
                 self.tokenizer.pad_token = self.tokenizer.eos_token
                 if self.tokenizer.pad_token is None:
                     self.tokenizer.add_special_tokens({'pad_token': '[PAD]'})
-            ids_info = self.tokenizer.batch_encode_plus(data,
+            ids_info = self.tokenizer.batch_encode_plus(list(data),
                                                         max_length=self.max_length,
                                                         truncation=self.truncation_strategy,
-                                                        pad_to_max_length=True)
+                                                        padding=self._padding_strategy)
         except ValueError:
             self.model.resize_token_embeddings(len(self.tokenizer))
-            ids_info = self.tokenizer.batch_encode_plus(data,
+            ids_info = self.tokenizer.batch_encode_plus(list(data),
                                                         max_length=self.max_length,
-                                                        pad_to_max_length=True)
+                                                        padding=self._padding_strategy)
         token_ids_batch = self.array2tensor(ids_info['input_ids'])
         mask_ids_batch = self.array2tensor(ids_info['attention_mask'])
         with self.no_gradients():

--- a/encoders/nlp/TransformerTorchEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTorchEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.8
+version: 0.0.9
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, pytorch]
 type: pod

--- a/encoders/nlp/TransformerTorchEncoder/requirements.txt
+++ b/encoders/nlp/TransformerTorchEncoder/requirements.txt
@@ -1,3 +1,3 @@
-transformers>=3.0.0
+transformers>=3.0.2
 torch>=1.6.0
 jina

--- a/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
+++ b/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
@@ -117,3 +117,10 @@ def test_parameter_override(encoder):
     assert encoder.pretrained_model_name_or_path == encoder_preset['pretrained_model_name_or_path']
     assert encoder.pooling_strategy == encoder_preset['pooling_strategy']
     assert encoder.model_save_path == encoder_preset['model_save_path']
+
+def test_max_length(test_metas):
+    encoder = TransformerTFEncoder(metas=test_metas, max_length=3)
+    test_data = np.array(['it is a very good day!', 'it is a very sunny day!'])
+    encoded_data = encoder.encode(test_data)
+
+    numpy.testing.assert_allclose(encoded_data[0], encoded_data[1])

--- a/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
+++ b/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
@@ -123,4 +123,4 @@ def test_max_length(test_metas):
     test_data = np.array(['it is a very good day!', 'it is a very sunny day!'])
     encoded_data = encoder.encode(test_data)
 
-    numpy.testing.assert_allclose(encoded_data[0], encoded_data[1])
+    np.testing.assert_allclose(encoded_data[0], encoded_data[1])

--- a/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
+++ b/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
@@ -64,7 +64,13 @@ encoders_parameters = [
         "pooling_strategy": 'max',
         "pretrained_model_name_or_path": 'xlnet-base-cased',
         "model_save_path": 'xlnet-base-cased-max',
-    }
+    },
+    {
+        "pooling_strategy": 'mean',
+        "pretrained_model_name_or_path": 'distilbert-base-cased',
+        "model_save_path": 'distilbert-base-cased-mean',
+        "max_length": 100
+    },
 ]
 
 

--- a/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
+++ b/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
@@ -119,7 +119,7 @@ def test_parameter_override(encoder):
     assert encoder.model_save_path == encoder_preset['model_save_path']
 
 def test_max_length(test_metas):
-    encoder = TransformerTFEncoder(metas=test_metas, max_length=3)
+    encoder = TransformerTorchEncoder(metas=test_metas, max_length=3)
     test_data = np.array(['it is a very good day!', 'it is a very sunny day!'])
     encoded_data = encoder.encode(test_data)
 


### PR DESCRIPTION
I have updated the transformer encoders to be compatible with the v4.0 of the transformers library. 

Two main changes:
- instead of passing in an `ndarray` of strings, this is converted to a list - otherwise an error is raised in version 4.0.0 of transformers.
- I have replaced the use of the deprecated `pad_to_max_length` parameter with `padding` parameter. This has no effect whatsoever on behavior of the function.

All these changes do not in any way change the behavior for earlier versions of transformers.

I have also updated the requirements files slightly: for TF, I have replaced `==` with `>=` for tensorflow version - this is consistent with the requirements file for torch transformers. There were no breaking changes in later versions of tensorflow (I have tested locally on 2.3.0), so I don't see the need for this limitation. Also, I have updated the requirement for transformers from `3.0.0` to `3.0.2` - `3.0.2` introduced important bugfixes for tokenizers for bugs in `3.0.0`, while there were no breaking changes.