### PR TITLE
fix: train_filepath can be none and loaded from binary

### DIFF
--- a/indexers/vector/FaissIndexer/__init__.py
+++ b/indexers/vector/FaissIndexer/__init__.py
@@ -1,7 +1,7 @@
 __copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from typing import Tuple
+from typing import Tuple, Optional
 
 import numpy as np
 from jina.executors.devices import FaissDevice
@@ -10,7 +10,6 @@ from jina.executors.decorators import batching
 
 
 class FaissIndexer(FaissDevice, BaseNumpyIndexer):
-
     batch_size = 512
 
     """Faiss powered vector indexer
@@ -22,8 +21,13 @@ class FaissIndexer(FaissDevice, BaseNumpyIndexer):
         Faiss package dependency is only required at the query time.
     """
 
-    def __init__(self, index_key: str, train_filepath: str = None,
-                 distance: str = 'l2', nprobe: int = 1, *args, **kwargs):
+    def __init__(self,
+                 index_key: str,
+                 train_filepath: Optional[str] = None,
+                 distance: str = 'l2',
+                 nprobe: int = 1,
+                 *args,
+                 **kwargs):
         """
         Initialize an Faiss Indexer
 
@@ -51,7 +55,7 @@ class FaissIndexer(FaissDevice, BaseNumpyIndexer):
             np.save(train_filepath, train_data)
             indexer = FaissIndexer('PCA64,FLAT', train_filepath)
         """
-        super().__init__(*args, compress_level=0, **kwargs)
+        super().__init__(*args, **kwargs)
         self.index_key = index_key
         self.train_filepath = train_filepath
         self.distance = distance
@@ -67,12 +71,12 @@ class FaissIndexer(FaissDevice, BaseNumpyIndexer):
             self.logger.warning('Invalid distance metric for Faiss index construction. Defaulting to l2 distance')
 
         index = self.to_device(index=faiss.index_factory(self.num_dim, self.index_key, metric))
-        if not self.is_trained:
+        if not self.is_trained and self.train_filepath:
             train_data = self._load_training_data(self.train_filepath)
             if train_data is None:
-                self.logger.warning('loading training data failed.')
-                return None
-            self.train(index, train_data)
+                self.logger.warning('loading training data failed. some faiss indexes require previous training.')
+            else:
+                self.train(index, train_data.astype(np.float32))
         self.build_partial_index(vecs, index)
         index.nprobe = self.nprobe
         return index
@@ -98,16 +102,23 @@ class FaissIndexer(FaissDevice, BaseNumpyIndexer):
         result = None
         try:
             result = self._load_gzip(train_filepath)
-            if result is not None:
-                return result
-        except OSError as e:
-            self.logger.info('not a gzippped file, {}'.format(e))
-
-        try:
-            result = np.load(train_filepath)
-            if isinstance(result, np.lib.npyio.NpzFile):
-                self.logger.warning('.npz format is not supported. Please save the array in .npy format.')
-                result = None
         except Exception as e:
-            self.logger.error('loading training data failed, filepath={}, {}'.format(train_filepath, e))
+            self.logger.error('loading training data from gzip failed, filepath={}, {}'.format(train_filepath, e))
+
+        if result is None:
+            try:
+                result = np.load(train_filepath)
+                if isinstance(result, np.lib.npyio.NpzFile):
+                    self.logger.warning('.npz format is not supported. Please save the array in .npy format.')
+                    result = None
+            except Exception as e:
+                self.logger.error('loading training data with np.load failed, filepath={}, {}'.format(train_filepath, e))
+
+        if result is None:
+            try:
+                # Read from binary file:
+                with open(train_filepath, 'rb') as f:
+                    result = f.read()
+            except Exception as e:
+                self.logger.error('loading training data from binary file failed, filepath={}, {}'.format(train_filepath, e))
         return result

--- a/indexers/vector/FaissIndexer/manifest.yml
+++ b/indexers/vector/FaissIndexer/manifest.yml
@@ -7,6 +7,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.8
+version: 0.0.9
 license: apache-2.0
 keywords: [vector, faiss, indexer, ANN]

--- a/indexers/vector/FaissIndexer/manifest.yml
+++ b/indexers/vector/FaissIndexer/manifest.yml
@@ -7,6 +7,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.9
+version: 0.0.10
 license: apache-2.0
 keywords: [vector, faiss, indexer, ANN]

--- a/indexers/vector/FaissIndexer/tests/test_faissindexer.py
+++ b/indexers/vector/FaissIndexer/tests/test_faissindexer.py
@@ -46,19 +46,29 @@ def test_faiss_indexer(metas):
         assert idx.shape == (10, 4)
 
 
-def test_faiss_indexer_known(metas):
+@pytest.mark.parametrize('compression_level', [0, 1, 2, 3])
+@pytest.mark.parametrize('train_data', ['new', 'none', 'index'])
+def test_faiss_indexer_known(metas, train_data, compression_level):
     vectors = np.array([[1, 1, 1],
                         [10, 10, 10],
                         [100, 100, 100],
                         [1000, 1000, 1000]], dtype=np.float32)
     keys = np.array([4, 5, 6, 7]).reshape(-1, 1)
 
-    train_filepath = os.path.join(os.environ['TEST_WORKSPACE'], 'train.tgz')
-    train_data = vectors
-    with gzip.open(train_filepath, 'wb', compresslevel=1) as f:
-        f.write(train_data.tobytes())
+    if train_data == 'new':
+        train_filepath = os.path.join(os.environ['TEST_WORKSPACE'], 'train.tgz')
+        train_data = vectors
+        with gzip.open(train_filepath, 'wb', compresslevel=1) as f:
+            f.write(train_data.tobytes())
+    elif train_data == 'none':
+        train_filepath = None
+    elif train_data == 'index':
+        train_filepath = os.path.join(metas['workspace'], 'faiss.test.gz')
 
-    with FaissIndexer(index_filename='faiss.test.gz', index_key='Flat', train_filepath=train_filepath,
+    with FaissIndexer(index_filename='faiss.test.gz',
+                      compression_level=compression_level,
+                      index_key='Flat',
+                      train_filepath=train_filepath,
                       metas=metas) as indexer:
         indexer.add(keys, vectors)
         indexer.save()
@@ -114,3 +124,32 @@ def test_faiss_indexer_known_big(metas):
         assert idx.shape == dist.shape
         assert idx.shape == (10, 1)
         np.testing.assert_equal(indexer.query_by_id([10000, 15000]), vectors[[0, 5000]])
+
+
+@pytest.mark.parametrize('compression_level', [0, 1, 2, 3, 4])
+def test_indexer_train_from_index_different_compression_levels(metas, compression_level):
+    np.random.seed(500)
+    num_data = 500
+    num_dim = 64
+    num_query = 10
+    query = np.array(np.random.random([num_query, num_dim]), dtype=np.float32)
+    vec_idx = np.random.randint(0, high=num_data, size=[num_data])
+    vec = np.random.random([num_data, num_dim])
+
+    train_filepath = os.path.join(metas['workspace'], 'faiss.test.gz')
+
+    with FaissIndexer(index_filename='faiss.test.gz',
+                      index_key='IVF10,PQ4',
+                      train_filepath=train_filepath,
+                      compression_level=compression_level,
+                      metas=metas) as indexer:
+        indexer.add(vec_idx, vec)
+        indexer.save()
+        assert os.path.exists(indexer.index_abspath)
+        save_abspath = indexer.save_abspath
+
+    with BaseIndexer.load(save_abspath) as indexer:
+        assert isinstance(indexer, FaissIndexer)
+        idx, dist = indexer.query(query, top_k=4)
+        assert idx.shape == dist.shape
+        assert idx.shape == (num_query, 4)


### PR DESCRIPTION
**Changes introduced**
Fixes #1288 .

- Does not force compression level
- Allows having no loading data if not needed.
- Allow training data from uncompressed data if required