### PR TITLE
refactor: hash to id for hub

### DIFF
--- a/rankers/BM25Ranker/__init__.py
+++ b/rankers/BM25Ranker/__init__.py
@@ -62,8 +62,8 @@ class BM25Ranker(Chunk2DocRanker):
         :return: a tuple of two `np.ndarray` in the size of ``M``, i.e. the document frequency array and the chunk id
             array. ``M`` is the number of query chunks.
         """
-        a = match_idx[match_idx[self.COL_DOC_CHUNK_HASH].argsort()]
-        q_id, q_df = np.unique(a[self.COL_DOC_CHUNK_HASH], return_counts=True)
+        a = match_idx[match_idx[self.COL_DOC_CHUNK_ID].argsort()]
+        q_id, q_df = np.unique(a[self.COL_DOC_CHUNK_ID], return_counts=True)
         return q_df, q_id
 
     def _get_tf(self, match_idx):
@@ -79,10 +79,10 @@ class BM25Ranker(Chunk2DocRanker):
             The query chunks with matching scores that is lower than the threshold are dropped.
         """
         _m = match_idx[match_idx[self.COL_SCORE] >= self.threshold]
-        _sorted_m = _m[_m[self.COL_DOC_CHUNK_HASH].argsort()]
-        q_id_list, q_tf_list = np.unique(_sorted_m[self.COL_DOC_CHUNK_HASH], return_counts=True)
+        _sorted_m = _m[_m[self.COL_DOC_CHUNK_ID].argsort()]
+        q_id_list, q_tf_list = np.unique(_sorted_m[self.COL_DOC_CHUNK_ID], return_counts=True)
         row_id = np.cumsum(q_tf_list) - 1
-        c_id_list = _sorted_m[row_id][self.COL_MATCH_HASH]
+        c_id_list = _sorted_m[row_id][self.COL_MATCH_ID]
         return q_tf_list, q_id_list, c_id_list
 
     def get_idf(self, match_idx):
@@ -138,8 +138,8 @@ class BM25Ranker(Chunk2DocRanker):
         """
         tf = self.get_tf(match_idx, match_chunk_meta)
         _weights = match_idx[self.COL_SCORE]
-        _q_tfidf = np.vectorize(tf.get)(match_idx[self.COL_DOC_CHUNK_HASH], 0) * \
-                   np.vectorize(idf.get)(match_idx[self.COL_DOC_CHUNK_HASH], 0)
+        _q_tfidf = np.vectorize(tf.get)(match_idx[self.COL_DOC_CHUNK_ID], 0) * \
+                   np.vectorize(idf.get)(match_idx[self.COL_DOC_CHUNK_ID], 0)
         _sum = np.sum(_q_tfidf)
         _doc_id = self.get_doc_id(match_idx)
         _score = 0. if _sum == 0 else np.sum(_weights * _q_tfidf) * 1.0 / _sum

--- a/rankers/BM25Ranker/manifest.yml
+++ b/rankers/BM25Ranker/manifest.yml
@@ -13,6 +13,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
 keywords: [ranker, toyexample, demo]

--- a/rankers/BM25Ranker/tests/test_bm25ranker.py
+++ b/rankers/BM25Ranker/tests/test_bm25ranker.py
@@ -34,9 +34,9 @@ def create_data():
     match_idx_numpy = np.array(
         match_idx,
         dtype=[
-            (Chunk2DocRanker.COL_MATCH_PARENT_HASH, np.int64),
-            (Chunk2DocRanker.COL_MATCH_HASH, np.int64),
-            (Chunk2DocRanker.COL_DOC_CHUNK_HASH, np.int64),
+            (Chunk2DocRanker.COL_MATCH_PARENT_ID, np.int64),
+            (Chunk2DocRanker.COL_MATCH_ID, np.int64),
+            (Chunk2DocRanker.COL_DOC_CHUNK_ID, np.int64),
             (Chunk2DocRanker.COL_SCORE, np.float64)
         ]
     )

--- a/rankers/BiMatchRanker/__init__.py
+++ b/rankers/BiMatchRanker/__init__.py
@@ -15,13 +15,13 @@ class BiMatchRanker(Chunk2DocRanker):
     D_MISS = 2000  # cost of a non-match chunk, used for normalization
 
     def _get_score(self, match_idx, query_chunk_meta, match_chunk_meta, *args, **kwargs):
-        s1 = self._directional_score(match_idx, match_chunk_meta, col=self.COL_MATCH_HASH)
-        s2 = self._directional_score(match_idx, query_chunk_meta, col=self.COL_DOC_CHUNK_HASH)
+        s1 = self._directional_score(match_idx, match_chunk_meta, col=self.COL_MATCH_ID)
+        s2 = self._directional_score(match_idx, query_chunk_meta, col=self.COL_DOC_CHUNK_ID)
         return self.get_doc_id(match_idx), (s1 + s2) / 2.
 
     def _directional_score(self, g, chunk_meta, col):
-        # col = self.COL_MATCH_HASH, from matched_chunk aspect
-        # col = self.COL_DOC_CHUNK_HASH, from query chunk aspect
+        # col = self.COL_MATCH_ID, from matched_chunk aspect
+        # col = self.COL_DOC_CHUNK_ID, from query chunk aspect
         # group by col
         _groups = self._group_by(g, col)
         # take the best match from each group

--- a/rankers/BiMatchRanker/manifest.yml
+++ b/rankers/BiMatchRanker/manifest.yml
@@ -6,7 +6,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
 keywords: [rank, bi-match, naive]
 type: pod

--- a/rankers/BiMatchRanker/tests/test_bimatchranker.py
+++ b/rankers/BiMatchRanker/tests/test_bimatchranker.py
@@ -34,9 +34,9 @@ def create_data():
     match_idx_numpy = np.array(
         match_idx,
         dtype=[
-            (Chunk2DocRanker.COL_MATCH_PARENT_HASH, np.int64),
-            (Chunk2DocRanker.COL_MATCH_HASH, np.int64),
-            (Chunk2DocRanker.COL_DOC_CHUNK_HASH, np.int64),
+            (Chunk2DocRanker.COL_MATCH_PARENT_ID, np.int64),
+            (Chunk2DocRanker.COL_MATCH_ID, np.int64),
+            (Chunk2DocRanker.COL_DOC_CHUNK_ID, np.int64),
             (Chunk2DocRanker.COL_SCORE, np.float64)
         ]
     )

--- a/rankers/LevenshteinRanker/__init__.py
+++ b/rankers/LevenshteinRanker/__init__.py
@@ -27,5 +27,5 @@ class LevenshteinRanker(Match2DocRanker):
         ]
         return np.array(
             new_scores,
-            dtype=[(self.COL_MATCH_HASH, np.int64), (self.COL_SCORE, np.float64)],
+            dtype=[(self.COL_MATCH_ID, np.int64), (self.COL_SCORE, np.float64)],
         )

--- a/rankers/LevenshteinRanker/manifest.yml
+++ b/rankers/LevenshteinRanker/manifest.yml
@@ -7,7 +7,7 @@ author: maximilian.werk@jina.ai
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.4
+version: 0.0.5
 license: apache-2.0
 keywords: [text matching, levenshtein, scorer]
 type: pod

--- a/rankers/LevenshteinRanker/tests/test_levenshteinranker.py
+++ b/rankers/LevenshteinRanker/tests/test_levenshteinranker.py
@@ -26,7 +26,7 @@ def test_levenshteinranker():
         new_scores,
         np.array(
             [(1, 0), (2, -3)],
-            dtype=[(Match2DocRanker.COL_MATCH_HASH, np.int64), (Match2DocRanker.COL_SCORE, np.float64)],
+            dtype=[(Match2DocRanker.COL_MATCH_ID, np.int64), (Match2DocRanker.COL_SCORE, np.float64)],
         )
     )
     # Guarantee no side-effects happen

--- a/rankers/MaxRanker/manifest.yml
+++ b/rankers/MaxRanker/manifest.yml
@@ -9,6 +9,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.8
+version: 0.0.9
 license: apache-2.0
 keywords: [ranker, toyexample, demo]

--- a/rankers/MaxRanker/tests/test_maxranker.py
+++ b/rankers/MaxRanker/tests/test_maxranker.py
@@ -34,9 +34,9 @@ def create_data():
     match_idx_numpy = np.array(
         match_idx,
         dtype=[
-            (Chunk2DocRanker.COL_MATCH_PARENT_HASH, np.int64),
-            (Chunk2DocRanker.COL_MATCH_HASH, np.int64),
-            (Chunk2DocRanker.COL_DOC_CHUNK_HASH, np.int64),
+            (Chunk2DocRanker.COL_MATCH_PARENT_ID, np.int64),
+            (Chunk2DocRanker.COL_MATCH_ID, np.int64),
+            (Chunk2DocRanker.COL_DOC_CHUNK_ID, np.int64),
             (Chunk2DocRanker.COL_SCORE, np.float64)
         ]
     )

--- a/rankers/MinRanker/manifest.yml
+++ b/rankers/MinRanker/manifest.yml
@@ -9,6 +9,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.8
+version: 0.0.9
 license: apache-2.0
 keywords: [ranker, toyexample, demo]

--- a/rankers/MinRanker/tests/test_minranker.py
+++ b/rankers/MinRanker/tests/test_minranker.py
@@ -34,9 +34,9 @@ def create_data():
     match_idx_numpy = np.array(
         match_idx,
         dtype=[
-            (Chunk2DocRanker.COL_MATCH_PARENT_HASH, np.int64),
-            (Chunk2DocRanker.COL_MATCH_HASH, np.int64),
-            (Chunk2DocRanker.COL_DOC_CHUNK_HASH, np.int64),
+            (Chunk2DocRanker.COL_MATCH_PARENT_ID, np.int64),
+            (Chunk2DocRanker.COL_MATCH_ID, np.int64),
+            (Chunk2DocRanker.COL_DOC_CHUNK_ID, np.int64),
             (Chunk2DocRanker.COL_SCORE, np.float64)
         ]
     )

--- a/rankers/SimpleAggregateRanker/manifest.yml
+++ b/rankers/SimpleAggregateRanker/manifest.yml
@@ -9,6 +9,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
 keywords: [ranker, aggregation]

--- a/rankers/SimpleAggregateRanker/tests/test_aggregate_ranker.py
+++ b/rankers/SimpleAggregateRanker/tests/test_aggregate_ranker.py
@@ -40,9 +40,9 @@ def chunk_scores(factor=1):
     match_idx_numpy = np.array(
         match_idx,
         dtype=[
-            (Chunk2DocRanker.COL_MATCH_PARENT_HASH, np.int64),
-            (Chunk2DocRanker.COL_MATCH_HASH, np.int64),
-            (Chunk2DocRanker.COL_DOC_CHUNK_HASH, np.int64),
+            (Chunk2DocRanker.COL_MATCH_PARENT_ID, np.int64),
+            (Chunk2DocRanker.COL_MATCH_ID, np.int64),
+            (Chunk2DocRanker.COL_DOC_CHUNK_ID, np.int64),
             (Chunk2DocRanker.COL_SCORE, np.float64)
         ]
     )

--- a/rankers/TfIdfRanker/__init__.py
+++ b/rankers/TfIdfRanker/__init__.py
@@ -98,8 +98,8 @@ class TfIdfRanker(Chunk2DocRanker):
         :return: a tuple of two `np.ndarray` in the size of ``M``, i.e. the document frequency array and the chunk id
             array. ``M`` is the number of query chunks.
         """
-        a = match_idx[match_idx[self.COL_DOC_CHUNK_HASH].argsort()]
-        q_id, q_df = np.unique(a[self.COL_DOC_CHUNK_HASH], return_counts=True)
+        a = match_idx[match_idx[self.COL_DOC_CHUNK_ID].argsort()]
+        q_id, q_df = np.unique(a[self.COL_DOC_CHUNK_ID], return_counts=True)
         return q_df, q_id
 
     def _get_tf(self, match_idx):
@@ -115,10 +115,10 @@ class TfIdfRanker(Chunk2DocRanker):
             The query chunks with matching scores that is lower than the threshold are dropped.
         """
         _m = match_idx[match_idx[self.COL_SCORE] >= self.threshold]
-        _sorted_m = _m[_m[self.COL_DOC_CHUNK_HASH].argsort()]
-        q_id_list, q_tf_list = np.unique(_sorted_m[self.COL_DOC_CHUNK_HASH], return_counts=True)
+        _sorted_m = _m[_m[self.COL_DOC_CHUNK_ID].argsort()]
+        q_id_list, q_tf_list = np.unique(_sorted_m[self.COL_DOC_CHUNK_ID], return_counts=True)
         row_id = np.cumsum(q_tf_list) - 1
-        c_id_list = _sorted_m[row_id][self.COL_MATCH_HASH]
+        c_id_list = _sorted_m[row_id][self.COL_MATCH_ID]
         return q_tf_list, q_id_list, c_id_list
 
     def _get_score(self, match_idx, query_chunk_meta, match_chunk_meta, idf, *args, **kwargs):
@@ -134,8 +134,8 @@ class TfIdfRanker(Chunk2DocRanker):
         """
         tf = self.get_tf(match_idx, match_chunk_meta)
         _weights = match_idx[self.COL_SCORE]
-        _q_tfidf = np.vectorize(tf.get)(match_idx[self.COL_DOC_CHUNK_HASH], 0) * \
-                   np.vectorize(idf.get)(match_idx[self.COL_DOC_CHUNK_HASH], 0)
+        _q_tfidf = np.vectorize(tf.get)(match_idx[self.COL_DOC_CHUNK_ID], 0) * \
+                   np.vectorize(idf.get)(match_idx[self.COL_DOC_CHUNK_ID], 0)
         _sum = np.sum(_q_tfidf)
         _doc_id = self.get_doc_id(match_idx)
         _score = 0. if _sum == 0 else np.sum(_weights * _q_tfidf) * 1.0 / _sum

--- a/rankers/TfIdfRanker/manifest.yml
+++ b/rankers/TfIdfRanker/manifest.yml
@@ -13,6 +13,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
 keywords: [ranker, toyexample, demo]

--- a/rankers/TfIdfRanker/tests/test_tfidfranker.py
+++ b/rankers/TfIdfRanker/tests/test_tfidfranker.py
@@ -34,9 +34,9 @@ def create_data():
     match_idx_numpy = np.array(
         match_idx,
         dtype=[
-            (Chunk2DocRanker.COL_MATCH_PARENT_HASH, np.int64),
-            (Chunk2DocRanker.COL_MATCH_HASH, np.int64),
-            (Chunk2DocRanker.COL_DOC_CHUNK_HASH, np.int64),
+            (Chunk2DocRanker.COL_MATCH_PARENT_ID, np.int64),
+            (Chunk2DocRanker.COL_MATCH_ID, np.int64),
+            (Chunk2DocRanker.COL_DOC_CHUNK_ID, np.int64),
             (Chunk2DocRanker.COL_SCORE, np.float64)
         ]
     )


### PR DESCRIPTION
This will adjust all Hub code to the hash to id change. We might need for another jina release before merging in order to make the core changes taking effect, right?