### PR TITLE
refactor: move transformer model loading to post_init

### DIFF
--- a/encoders/nlp/TransformerTFEncoder/__init__.py
+++ b/encoders/nlp/TransformerTFEncoder/__init__.py
@@ -101,7 +101,7 @@ class TransformerTFEncoder(TFDevice, BaseEncoder):
     def post_init(self):
         from transformers import TFAutoModel, AutoTokenizer
 
-        self.tokenizer = AutoTokenizer.from_pretrained(self.base_tokenizer_model)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.pretrained_model_name_or_path)
         self.model = TFAutoModel.from_pretrained(
             self.pretrained_model_name_or_path, output_hidden_states=True
         )

--- a/encoders/nlp/TransformerTFEncoder/__init__.py
+++ b/encoders/nlp/TransformerTFEncoder/__init__.py
@@ -101,7 +101,9 @@ class TransformerTFEncoder(TFDevice, BaseEncoder):
     def post_init(self):
         from transformers import TFAutoModel, AutoTokenizer
 
-        self.tokenizer = AutoTokenizer.from_pretrained(self.pretrained_model_name_or_path)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.pretrained_model_name_or_path
+        )
         self.model = TFAutoModel.from_pretrained(
             self.pretrained_model_name_or_path, output_hidden_states=True
         )

--- a/encoders/nlp/TransformerTFEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTFEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.10
+version: 0.0.11
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, tensorflow]
 type: pod

--- a/encoders/nlp/TransformerTorchEncoder/__init__.py
+++ b/encoders/nlp/TransformerTorchEncoder/__init__.py
@@ -81,20 +81,14 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
         """Get the file path of the encoder model storage"""
         return self.get_file_from_workspace(self.model_save_path)
 
-    @cached_property
-    def model(self):
-        from transformers import AutoModel
-        model = AutoModel.from_pretrained(
+    def post_init(self):
+        from transformers import AutoModel, AutoTokenizer
+
+        self.tokenizer = AutoTokenizer.from_pretrained(self.base_tokenizer_model)
+        self.model = AutoModel.from_pretrained(
             self.pretrained_model_name_or_path, output_hidden_states=True
         )
-        self.to_device(model)
-        return model
-
-    @cached_property
-    def tokenizer(self):
-        from transformers import AutoTokenizer
-        tokenizer = AutoTokenizer.from_pretrained(self.base_tokenizer_model)
-        return tokenizer
+        self.to_device(self.model)
 
     @batching
     @as_ndarray

--- a/encoders/nlp/TransformerTorchEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTorchEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.12
+version: 0.0.13
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, pytorch]
 type: pod


### PR DESCRIPTION
According to [BaseExecutor documentation](https://github.com/jina-ai/jina/blob/master/jina/executors/__init__.py#L219-L231), model loading should be done in `post_init`:

>  Initialize class attributes/members that can/should not be (de)serialized in standard way.
>  Examples:
>             **- deep learning models**
>             - index files
>             - numpy arrays

So I moved the loading of model/tokenizer for Transformer Encoders to `post_init`.

This also makes sense since jina logs the time taken in post_init and warns the user that this might take some time - while no such logging/warning is given for model loading outside of post_init, as it is done now