### PR TITLE
feat: torch transformer acceleration

### DIFF
--- a/encoders/nlp/TransformerTorchEncoder/__init__.py
+++ b/encoders/nlp/TransformerTorchEncoder/__init__.py
@@ -81,7 +81,7 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
             )
             raise NotImplementedError
 
-        if self.acceleration not in [None, "amp", "quant"]:
+        if self.acceleration not in [None, 'amp', 'quant']:
             self.logger.error(
                 f'acceleration not found: {self.acceleration}.'
                 ' The allowed accelerations are "amp" and "quant".'
@@ -114,7 +114,7 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
         )
         self.to_device(model)
         
-        if self.acceleration == "quant" and not self.on_gpu:
+        if self.acceleration == 'quant' and not self.on_gpu:
             model = torch.quantization.quantize_dynamic(
                 model, {torch.nn.Linear}, dtype=torch.qint8
             )     
@@ -131,7 +131,7 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
         import torch
         from contextlib import nullcontext
 
-        if self.acceleration == "amp":
+        if self.acceleration == 'amp':
             return torch.cuda.amp.autocast()
         else:
             return nullcontext()

--- a/encoders/nlp/TransformerTorchEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTorchEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.13
+version: 0.0.14
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, pytorch]
 type: pod

--- a/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
+++ b/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
@@ -68,10 +68,10 @@ def test_encoding_results(test_metas, model_name, pooling_strategy, layer_index)
     else:
         assert np.allclose(encoded_data[0], encoded_data[1], atol=1e-5, rtol=1e-4)
 
-@pytest.mark.parametrize('acceleration', ["amp", "quant"])
+@pytest.mark.parametrize('acceleration', ['amp', 'quant'])
 def test_encoding_results_acceleration(test_metas, acceleration):
 
-    if 'JINA_TEST_GPU' in os.environ and acceleration == "quant":
+    if 'JINA_TEST_GPU' in os.environ and acceleration == 'quant':
         pytest.skip("Can't test quantization on GPU.")
 
     encoder = get_encoder(test_metas, **{"acceleration": acceleration})

--- a/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
+++ b/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
@@ -68,6 +68,19 @@ def test_encoding_results(test_metas, model_name, pooling_strategy, layer_index)
     else:
         assert np.allclose(encoded_data[0], encoded_data[1], atol=1e-5, rtol=1e-4)
 
+@pytest.mark.parametrize('acceleration', ["amp", "quant"])
+def test_encoding_results_acceleration(test_metas, acceleration):
+
+    if 'JINA_TEST_GPU' in os.environ and acceleration == "quant":
+        pytest.skip("Can't test quantization on GPU.")
+
+    encoder = get_encoder(test_metas, **{"acceleration": acceleration})
+
+    test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
+    encoded_data = encoder.encode(test_data)
+
+    assert encoded_data.shape == (2, 768)
+    assert not np.allclose(encoded_data[0], encoded_data[1], rtol=1)
 
 @pytest.mark.parametrize('model_name', ['bert-base-uncased'])
 @pytest.mark.parametrize('pooling_strategy', ['cls', 'mean', 'max'])
@@ -169,6 +182,9 @@ def test_wrong_pooling_strategy():
     with pytest.raises(NotImplementedError):
         TransformerTorchEncoder(pooling_strategy='wrong')
 
+def test_wrong_pooling_acceleration():
+    with pytest.raises(NotImplementedError):
+        TransformerTorchEncoder(acceleration='wrong')
 
 @pytest.mark.parametrize(
     'params',


### PR DESCRIPTION
This adds 2 acceleration options to torch transformer: AMP and quantization. Here's a [notebook](https://colab.research.google.com/drive/1GEdRZXwr_vHIL9suzhHmE-jWezZMwv_R?usp=sharing) that demonstrates that these two acceleration options deliver a performance benefit - they can make the encoding up to 2x faster. Though this leads to loss of precision, so it should be used with care (a warning to this effect is added in the docstring).