### PR TITLE
refactor: move model loading to post init for TorchTransformer

### DIFF
--- a/encoders/nlp/TransformerTorchEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTorchEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.14
+version: 0.0.15
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, pytorch]
 type: pod


### PR DESCRIPTION
This moves model and tokenizer loading to post_init function.