### PR TITLE
fix: imageresizer gray

### DIFF
--- a/crafters/image/ImageResizer/helper.py
+++ b/crafters/image/ImageResizer/helper.py
@@ -22,6 +22,8 @@ def _load_image(blob: 'np.ndarray', channel_axis: int):
 
     from PIL import Image
     img = _move_channel_axis(blob, channel_axis)
+    if len(img.shape) == 3 and img.shape[2] == 1:
+        img = img[:, :, 0]
     return Image.fromarray(img.astype('uint8'))
 
 
@@ -50,7 +52,8 @@ def _crop_image(img, target_size: Union[Tuple[int, int], int], top: int = None, 
     elif isinstance(target_size, Tuple) and len(target_size) == 2:
         target_h, target_w = target_size
     else:
-        raise ValueError(f'target_size should be an integer or a tuple of two integers: {target_size}')
+        raise ValueError(
+            f'target_size should be an integer or a tuple of two integers: {target_size}')
     w_beg = left
     h_beg = top
     if how == 'center':
@@ -61,14 +64,18 @@ def _crop_image(img, target_size: Union[Tuple[int, int], int], top: int = None, 
         h_beg = np.random.randint(0, img_h - target_h + 1)
     elif how == 'precise':
         assert (w_beg is not None and h_beg is not None)
-        assert (0 <= w_beg <= (img_w - target_w)), f'left must be within [0, {img_w - target_w}]: {w_beg}'
-        assert (0 <= h_beg <= (img_h - target_h)), f'top must be within [0, {img_h - target_h}]: {h_beg}'
+        assert (0 <= w_beg <= (img_w - target_w)
+                ), f'left must be within [0, {img_w - target_w}]: {w_beg}'
+        assert (0 <= h_beg <= (img_h - target_h)
+                ), f'top must be within [0, {img_h - target_h}]: {h_beg}'
     else:
         raise ValueError(f'unknown input how: {how}')
     if not isinstance(w_beg, int):
-        raise ValueError(f'left must be int number between 0 and {img_w}: {left}')
+        raise ValueError(
+            f'left must be int number between 0 and {img_w}: {left}')
     if not isinstance(h_beg, int):
-        raise ValueError(f'top must be int number between 0 and {img_h}: {top}')
+        raise ValueError(
+            f'top must be int number between 0 and {img_h}: {top}')
     w_end = w_beg + target_w
     h_end = h_beg + target_h
     img = img.crop((w_beg, h_beg, w_end, h_end))
@@ -94,6 +101,8 @@ def _resize_short(img, target_size: Union[Tuple[int, int], int], how: str = 'LAN
     elif isinstance(target_size, Tuple) and len(target_size) == 2:
         target_h, target_w = target_size
     else:
-        raise ValueError(f'target_size should be an integer or a tuple of two integers: {target_size}')
+        raise ValueError(
+            f'target_size should be an integer or a tuple of two integers: {target_size}')
+
     img = img.resize((target_w, target_h), getattr(Image, how))
     return img

--- a/crafters/image/ImageResizer/manifest.yml
+++ b/crafters/image/ImageResizer/manifest.yml
@@ -7,6 +7,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.13
+version: 0.0.14
 license: apache-2.0
 keywords: [Some keywords to describe the executor, separated by commas]

--- a/crafters/image/ImageResizer/tests/test_imageresizer.py
+++ b/crafters/image/ImageResizer/tests/test_imageresizer.py
@@ -1,3 +1,4 @@
+import pytest
 from .. import ImageResizer
 
 
@@ -35,14 +36,16 @@ def test_resize():
     assert crafted_doc['blob'].shape[:-1] == output_dim
 
 
-def test_resize_gray():
+@pytest.mark.parametrize('img_array', [create_random_gray_img_array(17, 20),
+                                       create_random_gray_img_array_2d(17, 20)]
+                         )
+def test_resize_gray(img_array):
     img_width = 20
     img_height = 17
 
     # Test for int target_size
     output_dim = 71
     crafter = ImageResizer(target_size=output_dim)
-    img_array = create_random_gray_img_array(img_height, img_width)
     crafted_doc = crafter.craft(img_array)
     assert min(crafted_doc['blob'].shape[:-1]) == output_dim
 
@@ -50,24 +53,5 @@ def test_resize_gray():
     output_dim = (img_height, img_width)
     crafter = ImageResizer(target_size=output_dim)
     img_array = create_random_gray_img_array(img_width, img_height)
-    crafted_doc = crafter.craft(img_array)
-    assert crafted_doc['blob'].shape == output_dim
-
-
-def test_resize_gray_2d():
-    img_width = 20
-    img_height = 17
-
-    # Test for int target_size
-    output_dim = 71
-    crafter = ImageResizer(target_size=output_dim)
-    img_array = create_random_gray_img_array_2d(img_height, img_width)
-    crafted_doc = crafter.craft(img_array)
-    assert min(crafted_doc['blob'].shape[:-1]) == output_dim
-
-    # Test for tuple/list target_size
-    output_dim = (img_height, img_width)
-    crafter = ImageResizer(target_size=output_dim)
-    img_array = create_random_gray_img_array_2d(img_width, img_height)
     crafted_doc = crafter.craft(img_array)
     assert crafted_doc['blob'].shape == output_dim

--- a/crafters/image/ImageResizer/tests/test_imageresizer.py
+++ b/crafters/image/ImageResizer/tests/test_imageresizer.py
@@ -52,6 +52,5 @@ def test_resize_gray(img_array):
     # Test for tuple/list target_size
     output_dim = (img_height, img_width)
     crafter = ImageResizer(target_size=output_dim)
-    img_array = create_random_gray_img_array(img_width, img_height)
     crafted_doc = crafter.craft(img_array)
     assert crafted_doc['blob'].shape == output_dim

--- a/crafters/image/ImageResizer/tests/test_imageresizer.py
+++ b/crafters/image/ImageResizer/tests/test_imageresizer.py
@@ -28,3 +28,22 @@ def test_resize():
     img_array = create_random_img_array(img_width, img_height)
     crafted_doc = crafter.craft(img_array)
     assert crafted_doc['blob'].shape[:-1] == output_dim
+
+
+def test_resize_gray():
+    img_width = 20
+    img_height = 17
+
+    # Test for int target_size
+    output_dim = 71
+    crafter = ImageResizer(target_size=output_dim)
+    img_array = create_random_gray_img_array(img_height, img_width)
+    crafted_doc = crafter.craft(img_array)
+    assert min(crafted_doc['blob'].shape[:-1]) == output_dim
+
+    # Test for tuple/list target_size
+    output_dim = (img_height, img_width)
+    crafter = ImageResizer(target_size=output_dim)
+    img_array = create_random_gray_img_array(img_width, img_height)
+    crafted_doc = crafter.craft(img_array)
+    assert crafted_doc['blob'].shape == output_dim

--- a/crafters/image/ImageResizer/tests/test_imageresizer.py
+++ b/crafters/image/ImageResizer/tests/test_imageresizer.py
@@ -6,10 +6,15 @@ def create_random_img_array(img_height, img_width):
     return np.random.randint(0, 256, (img_height, img_width, 3))
 
 
+def create_random_gray_img_array(img_height, img_width):
+    import numpy as np
+    return np.random.randint(0, 256, (img_height, img_width, 1))
+
+
 def test_resize():
     img_width = 20
     img_height = 17
-    
+
     # Test for int target_size
     output_dim = 71
     crafter = ImageResizer(target_size=output_dim)

--- a/crafters/image/ImageResizer/tests/test_imageresizer.py
+++ b/crafters/image/ImageResizer/tests/test_imageresizer.py
@@ -11,6 +11,11 @@ def create_random_gray_img_array(img_height, img_width):
     return np.random.randint(0, 256, (img_height, img_width, 1))
 
 
+def create_random_gray_img_array_2d(img_height, img_width):
+    import numpy as np
+    return np.random.randint(0, 256, (img_height, img_width))
+
+
 def test_resize():
     img_width = 20
     img_height = 17
@@ -45,5 +50,24 @@ def test_resize_gray():
     output_dim = (img_height, img_width)
     crafter = ImageResizer(target_size=output_dim)
     img_array = create_random_gray_img_array(img_width, img_height)
+    crafted_doc = crafter.craft(img_array)
+    assert crafted_doc['blob'].shape == output_dim
+
+
+def test_resize_gray_2d():
+    img_width = 20
+    img_height = 17
+
+    # Test for int target_size
+    output_dim = 71
+    crafter = ImageResizer(target_size=output_dim)
+    img_array = create_random_gray_img_array_2d(img_height, img_width)
+    crafted_doc = crafter.craft(img_array)
+    assert min(crafted_doc['blob'].shape[:-1]) == output_dim
+
+    # Test for tuple/list target_size
+    output_dim = (img_height, img_width)
+    crafter = ImageResizer(target_size=output_dim)
+    img_array = create_random_gray_img_array_2d(img_width, img_height)
     crafted_doc = crafter.craft(img_array)
     assert crafted_doc['blob'].shape == output_dim


### PR DESCRIPTION
it closes #165 

* added exception in the image resizer to work with 2d arrays or 3d arrays with shape (x, y, 1) 