### PR TITLE
reformat: clean transformers

### DIFF
--- a/encoders/nlp/TransformerTFEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTFEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.15
+version: 0.0.16
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, tensorflow]
 type: pod

--- a/encoders/nlp/TransformerTFEncoder/tests/test_transformertfencoder.py
+++ b/encoders/nlp/TransformerTFEncoder/tests/test_transformertfencoder.py
@@ -17,15 +17,6 @@ def test_metas(tmp_path):
     yield metas
 
 
-def get_encoder(test_metas, **kwargs):
-    if 'pretrained_model_name_or_path' in kwargs and 'pooling_strategy' in kwargs:
-        kwargs['model_save_path'] = (
-                kwargs['pretrained_model_name_or_path'].replace('/', '.')
-                + f'-{kwargs["pooling_strategy"]}'
-        )
-    return TransformerTFEncoder(metas=test_metas, **kwargs)
-
-
 _models = [
     'distilbert-base-uncased',
     'bert-base-uncased',
@@ -48,7 +39,7 @@ def test_encoding_results(test_metas, model_name, pooling_strategy, layer_index)
         'pooling_strategy': pooling_strategy,
         'layer_index': layer_index
     }
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTFEncoder(metas=test_metas, **params)
 
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
     encoded_data = encoder.encode(test_data)
@@ -80,7 +71,7 @@ def test_embedding_consistency(test_metas, model_name, pooling_strategy, layer_i
     }
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
 
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTFEncoder(metas=test_metas, **params)
     encoded_data = encoder.encode(test_data)
 
     encoded_data_file = f'tests/{model_name}-{pooling_strategy}-{layer_index}.npy'
@@ -99,7 +90,7 @@ def test_max_length_truncation(test_metas, model_name, pooling_strategy, layer_i
         'layer_index': layer_index,
         'max_length': 3
     }
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTFEncoder(metas=test_metas, **params)
     test_data = np.array(['it is a very good day!', 'it is a very sunny day!'])
     encoded_data = encoder.encode(test_data)
 
@@ -116,7 +107,7 @@ def test_shape_single_document(test_metas, model_name, pooling_strategy, layer_i
         'layer_index': layer_index,
         'max_length': 3
     }
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTFEncoder(metas=test_metas, **params)
     test_data = np.array(['it is a very good day!'])
     encoded_data = encoder.encode(test_data)
     assert len(encoded_data.shape) == 2
@@ -132,7 +123,7 @@ def test_save_and_load(test_metas, model_name, pooling_strategy, layer_index):
         'pooling_strategy': pooling_strategy,
         'layer_index': layer_index
     }
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTFEncoder(metas=test_metas, **params)
 
     encoder.save_config()
     _assert_params_equal(params, encoder)
@@ -161,7 +152,7 @@ def test_save_and_load_config(test_metas, model_name, pooling_strategy, layer_in
         'pooling_strategy': pooling_strategy,
         'layer_index': layer_index
     }
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTFEncoder(metas=test_metas, **params)
 
     encoder.save_config()
     _assert_params_equal(params, encoder)
@@ -174,7 +165,7 @@ def test_save_and_load_config(test_metas, model_name, pooling_strategy, layer_in
 @pytest.mark.parametrize('layer_index', [-100, 100])
 def test_wrong_layer_index(test_metas, layer_index):
     params = {'layer_index': layer_index}
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTFEncoder(metas=test_metas, **params)
 
     encoder.layer_index = layer_index
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
@@ -191,7 +182,7 @@ def test_wrong_pooling_strategy():
     [{'pooling_strategy': 'cls', 'pretrained_model_name_or_path': 'gpt2'}],
 )
 def test_no_cls_token(test_metas, params):
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTFEncoder(metas=test_metas, **params)
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
     with pytest.raises(ValueError):
         encoder.encode(test_data)

--- a/encoders/nlp/TransformerTorchEncoder/__init__.py
+++ b/encoders/nlp/TransformerTorchEncoder/__init__.py
@@ -24,7 +24,6 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
             layer_index: int = -1,
             max_length: Optional[int] = None,
             acceleration: Optional[str] = None,
-            model_save_path: Optional[str] = None,
             *args,
             **kwargs,
     ):
@@ -47,11 +46,6 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
             ..note::
                 While acceleration methods can significantly speed up the encoding, they result in loss of precision.
                 Make sure that the tradeoff is worthwhile for your use case.
-
-        :param model_save_path: the path of the encoder model. If a valid path is given, the encoder will be saved to the given path
-
-        ..warning::
-            `model_save_path` should be relative to executor's workspace
         """
 
         super().__init__(*args, **kwargs)
@@ -61,7 +55,6 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
         self.layer_index = layer_index
         self.max_length = max_length
         self.acceleration = acceleration
-        self.model_save_path = model_save_path
 
         if self.pooling_strategy == 'auto':
             self.pooling_strategy = 'cls'
@@ -83,22 +76,6 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
                 ' The allowed accelerations are "amp" and "quant".'
             )
             raise NotImplementedError
-
-    def __getstate__(self):
-        if self.model_save_path:
-            if not os.path.exists(self.model_abspath):
-                self.logger.info(
-                    f'create folder for saving transformer models: {self.model_abspath}'
-                )
-                os.mkdir(self.model_abspath)
-            self.model.save_pretrained(self.model_abspath)
-            self.tokenizer.save_pretrained(self.model_abspath)
-        return super().__getstate__()
-
-    @property
-    def model_abspath(self) -> str:
-        """Get the file path of the encoder model storage"""
-        return self.get_file_from_workspace(self.model_save_path)
 
     def post_init(self):
         import torch

--- a/encoders/nlp/TransformerTorchEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTorchEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.20
+version: 0.0.21
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, pytorch]
 type: pod

--- a/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
+++ b/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
@@ -17,15 +17,6 @@ def test_metas(tmp_path):
     yield metas
 
 
-def get_encoder(test_metas, **kwargs):
-    if 'pretrained_model_name_or_path' in kwargs and 'pooling_strategy' in kwargs:
-        kwargs['model_save_path'] = (
-                kwargs['pretrained_model_name_or_path'].replace('/', '.')
-                + f'-{kwargs["pooling_strategy"]}'
-        )
-    return TransformerTorchEncoder(metas=test_metas, **kwargs)
-
-
 _models = [
     'sentence-transformers/distilbert-base-nli-stsb-mean-tokens',
     'sentence-transformers/bert-base-nli-stsb-mean-tokens',
@@ -49,7 +40,7 @@ def test_encoding_results(test_metas, model_name, pooling_strategy, layer_index)
         'pooling_strategy': pooling_strategy,
         'layer_index': layer_index
     }
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTorchEncoder(metas=test_metas, **params)
 
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
     encoded_data = encoder.encode(test_data)
@@ -75,7 +66,7 @@ def test_encoding_results_acceleration(test_metas, acceleration):
     if 'JINA_TEST_GPU' in os.environ and acceleration == 'quant':
         pytest.skip("Can't test quantization on GPU.")
 
-    encoder = get_encoder(test_metas, **{"acceleration": acceleration})
+    encoder = TransformerTorchEncoder(metas=test_metas, **{"acceleration": acceleration})
 
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
     encoded_data = encoder.encode(test_data)
@@ -95,7 +86,7 @@ def test_embedding_consistency(test_metas, model_name, pooling_strategy, layer_i
     }
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
 
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTorchEncoder(metas=test_metas, **params)
     encoded_data = encoder.encode(test_data)
 
     encoded_data_file = f'tests/{model_name}-{pooling_strategy}-{layer_index}.npy'
@@ -114,7 +105,7 @@ def test_max_length_truncation(test_metas, model_name, pooling_strategy, layer_i
         'layer_index': layer_index,
         'max_length': 3
     }
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTorchEncoder(metas=test_metas, **params)
     test_data = np.array(['it is a very good day!', 'it is a very sunny day!'])
     encoded_data = encoder.encode(test_data)
 
@@ -131,7 +122,7 @@ def test_shape_single_document(test_metas, model_name, pooling_strategy, layer_i
         'layer_index': layer_index,
         'max_length': 3
     }
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTorchEncoder(metas=test_metas, **params)
     test_data = np.array(['it is a very good day!'])
     encoded_data = encoder.encode(test_data)
     assert len(encoded_data.shape) == 2
@@ -147,7 +138,7 @@ def test_save_and_load(test_metas, model_name, pooling_strategy, layer_index):
         'pooling_strategy': pooling_strategy,
         'layer_index': layer_index
     }
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTorchEncoder(metas=test_metas, **params)
     test_data = np.array(['a', 'b', 'c', 'x', '!'])
     encoded_data_control = encoder.encode(test_data)
 
@@ -171,7 +162,7 @@ def test_save_and_load_config(test_metas, model_name, pooling_strategy, layer_in
         'pooling_strategy': pooling_strategy,
         'layer_index': layer_index
     }
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTorchEncoder(metas=test_metas, **params)
 
     encoder.save_config()
     _assert_params_equal(params, encoder)
@@ -184,7 +175,7 @@ def test_save_and_load_config(test_metas, model_name, pooling_strategy, layer_in
 @pytest.mark.parametrize('layer_index', [-100, 100])
 def test_wrong_layer_index(test_metas, layer_index):
     params = {'layer_index': layer_index}
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTorchEncoder(metas=test_metas, **params)
 
     encoder.layer_index = layer_index
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
@@ -207,7 +198,7 @@ def test_wrong_pooling_acceleration():
     [{'pooling_strategy': 'cls', 'pretrained_model_name_or_path': 'gpt2'}],
 )
 def test_no_cls_token(test_metas, params):
-    encoder = get_encoder(test_metas, **params)
+    encoder = TransformerTorchEncoder(metas=test_metas, **params)
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
     with pytest.raises(ValueError):
         _ = encoder.encode(test_data)


### PR DESCRIPTION
This removes model/tokenizer saving from transformer encoders.

They are not needed as the models are simply used pretrained, no training (modification) is done.