### PR TITLE
feat: add documentation for big transfer encoder

### DIFF
--- a/encoders/image/BigTransferEncoder/README.md
+++ b/encoders/image/BigTransferEncoder/README.md
@@ -7,6 +7,8 @@ Additional links:
 - [BiT Research Paper](https://arxiv.org/abs/1912.11370)
 
 Usage:
+
 Initialise this executor specifying parameters i.e. `model_path` (the directory path of the model in the `SavedModel` format), `model_name` (includes `R50x1`, `R101x1`, `R50x3`, `R101x3`, `R152x4`) `channel_axis` (axis id of the channel), etc.
+Snippet:
 `BigTransferEncoder(model_path='pretrained', channel_axis=1, metas=metas)`
 

--- a/encoders/image/BigTransferEncoder/README.md
+++ b/encoders/image/BigTransferEncoder/README.md
@@ -6,3 +6,7 @@ Additional links:
 - [Google AI Blog](https://ai.googleblog.com/2020/05/open-sourcing-bit-exploring-large-scale.html)
 - [BiT Research Paper](https://arxiv.org/abs/1912.11370)
 
+Usage:
+Initialise this executor specifying parameters i.e. `model_path` (the directory path of the model in the `SavedModel` format), `model_name` (includes `R50x1`, `R101x1`, `R50x3`, `R101x3`, `R152x4`) `channel_axis` (axis id of the channel), etc.
+`BigTransferEncoder(model_path='pretrained', channel_axis=1, metas=metas)`
+

--- a/encoders/image/BigTransferEncoder/README.md
+++ b/encoders/image/BigTransferEncoder/README.md
@@ -55,11 +55,11 @@ Users can use Pod images in several ways:
     
 - Docker command
 
-  Specify the image name along with the version tag. The snippet below uses Jina version `0.9.20`
-  
-  -```Dockerfile
-   docker pull jinahub/pod.encoder.bigtransferencoder:0.0.6-0.9.33
-   ```
+  - Specify the image name along with the version tag. The snippet below uses Jina version `0.9.20`
+
+  - ```bash
+    docker pull jinahub/pod.encoder.bigtransferencoder:0.0.6-0.9.33
+    ```
    
  Note:
  

--- a/encoders/image/BigTransferEncoder/README.md
+++ b/encoders/image/BigTransferEncoder/README.md
@@ -6,9 +6,10 @@ Additional links:
 - [Google AI Blog](https://ai.googleblog.com/2020/05/open-sourcing-bit-exploring-large-scale.html)
 - [BiT Research Paper](https://arxiv.org/abs/1912.11370)
 
-Usage:
+## Usage:
 
 Initialise this executor specifying parameters i.e. `model_path` (the directory path of the model in the `SavedModel` format), `model_name` (includes `R50x1`, `R101x1`, `R50x3`, `R101x3`, `R152x4`) `channel_axis` (axis id of the channel), etc.
-Snippet:
+
+### Snippet:
 `BigTransferEncoder(model_path='pretrained', channel_axis=1, metas=metas)`
 

--- a/encoders/image/BigTransferEncoder/README.md
+++ b/encoders/image/BigTransferEncoder/README.md
@@ -1,14 +1,24 @@
 # BigTransferEncoder
 
-`BigTransferEncoder` is Big Transfer (BiT) presented by Google (https://github.com/google-research/big_transfer), is a State-of-the-art transfer learning model for computer vision. This class uses pretrained BiT to encode data from an `ndarray`, potentially B x (Channel x Height x Width) into an `ndarray` of shape `B x D`. Internally, :class:`BigTransferEncoder` wraps the models from https://storage.googleapis.com/bit_models/.
+`BigTransferEncoder` is [Big Transfer (BiT) presented by Google](https://github.com/google-research/big_transfer), is a State-of-the-art transfer learning model for computer vision. This class uses pretrained BiT to encode data from an `ndarray`, potentially B x (Channel x Height x Width) into an `ndarray` of shape `B x D`. Internally, :class:`BigTransferEncoder` wraps the models from [here](https://storage.googleapis.com/bit_models/).
 Additional links:
 - [Tensorflow Blog](https://blog.tensorflow.org/2020/05/bigtransfer-bit-state-of-art-transfer-learning-computer-vision.html)
 - [Google AI Blog](https://ai.googleblog.com/2020/05/open-sourcing-bit-exploring-large-scale.html)
 - [BiT Research Paper](https://arxiv.org/abs/1912.11370)
 
+The model is pre-trained on Imagenet data
+
+
 ## Usage:
 
-Initialise this executor specifying parameters i.e. `model_path` (the directory path of the model in the `SavedModel` format), `model_name` (includes `R50x1`, `R101x1`, `R50x3`, `R101x3`, `R152x4`) `channel_axis` (axis id of the channel), etc.
+Initialise this Executor specifying parameters i.e.:
+------------------------------------------------------------------------------
+| `param_name`  | `param_remarks`                                            |
+|`model_path`   |the directory path of the model in the `SavedModel` format  |
+|`model_name`   | includes `R50x1`, `R101x1`, `R50x3`, `R101x3`, `R152x4`    |
+|`channel_axis` | axis id of the channel), etc.                              |
+------------------------------------------------------------------------------
+The pretrained default path is the result of downloading the models in `download.sh`
 
 ### Snippet:
 `BigTransferEncoder(model_path='pretrained', channel_axis=1, metas=metas)`

--- a/encoders/image/BigTransferEncoder/README.md
+++ b/encoders/image/BigTransferEncoder/README.md
@@ -1,25 +1,62 @@
 # BigTransferEncoder
 
-`BigTransferEncoder` is [Big Transfer (BiT) presented by Google](https://github.com/google-research/big_transfer), is a State-of-the-art transfer learning model for computer vision. This class uses pretrained BiT to encode data from an `ndarray`, potentially B x (Channel x Height x Width) into an `ndarray` of shape `B x D`. Internally, :class:`BigTransferEncoder` wraps the models from [here](https://storage.googleapis.com/bit_models/).
+BigTransferEncoder from [Big Transfer (BiT)](https://github.com/google-research/big_transfer) is Google's state-of-the-art transfer learning model for computer vision. This class uses pretrained BiT to encode data from an `ndarray`, potentially B x (Channel x Height x Width) into an `ndarray` of shape `B x D`. Internally, :class:`BigTransferEncoder` wraps the models from [here](https://storage.googleapis.com/bit_models/).
 Additional links:
 - [Tensorflow Blog](https://blog.tensorflow.org/2020/05/bigtransfer-bit-state-of-art-transfer-learning-computer-vision.html)
 - [Google AI Blog](https://ai.googleblog.com/2020/05/open-sourcing-bit-exploring-large-scale.html)
 - [BiT Research Paper](https://arxiv.org/abs/1912.11370)
 
-The model is pre-trained on Imagenet data
+The model is pre-trained on [ImageNet](http://www.image-net.org/) data
 
 
 ## Usage:
 
 Initialise this Executor specifying parameters i.e.:
-------------------------------------------------------------------------------
-| `param_name`  | `param_remarks`                                            |
-|`model_path`   |the directory path of the model in the `SavedModel` format  |
-|`model_name`   | includes `R50x1`, `R101x1`, `R50x3`, `R101x3`, `R152x4`    |
-|`channel_axis` | axis id of the channel), etc.                              |
-------------------------------------------------------------------------------
+
+| `param_name`  | `param_remarks` |
+| ------------- | ------------- |
+| `model_path`  | the directory path of the model in the `SavedModel` format  |
+| `model_name`  | includes `R50x1`, `R101x1`, `R50x3`, `R101x3`, `R152x4`  |
+| `channel_axis`| axis id of the channel), etc.  |
+
 The pretrained default path is the result of downloading the models in `download.sh`
 
-### Snippet:
+### Usage snippet:
 `BigTransferEncoder(model_path='pretrained', channel_axis=1, metas=metas)`
 
+Users can use Pod images in several ways:
+
+- Run with Docker (`docker run`)
+  - ```bash
+    docker run jinahub/pod.encoder.bigtransferencoder --port-in 55555 --port-out 55556
+    ```
+    
+- Flow API
+  - ```python
+    from jina.flow import Flow
+
+    f = (Flow()
+        .add(name='my-encoder', image='jinahub/pod.encoder.bigtransferencoder', port_in=55555, port_out=55556)
+        .add(name='my-indexer', uses='indexer.yml'))
+    ```
+    
+- Jina CLI
+  - ```bash
+    jina pod --uses jinahub/pod.encoder.bigtransferencoder --port-in 55555 --port-out 55556
+    ```
+    
+- Conventional local usage with `uses` argument
+  - ```bash
+    jina pod --uses hub/example/bigtransferencoder.yml --port-in 55555 --port-out 55556
+    ```
+    
+- Docker command
+
+  Specify the image name along with the version tag. The snippet below uses Jina version `0.9.20`
+  
+  -```Dockerfile
+   docker pull jinahub/pod.encoder.bigtransferencoder:0.0.6-0.9.20
+   ```
+   
+  
+   

--- a/encoders/image/BigTransferEncoder/README.md
+++ b/encoders/image/BigTransferEncoder/README.md
@@ -31,7 +31,7 @@ Users can use Pod images in several ways:
 
 - Run with Docker (`docker run`)
   - ```bash
-    docker run jinahub/pod.encoder.bigtransferencoder --port-in 55555 --port-out 55556
+    docker run jinahub/pod.encoder.bigtransferencoder:0.0.6-0.9.33 --port-in 55555 --port-out 55556
     ```
     
 - Flow API
@@ -39,13 +39,13 @@ Users can use Pod images in several ways:
     from jina.flow import Flow
 
     f = (Flow()
-        .add(name='my-encoder', image='jinahub/pod.encoder.bigtransferencoder', port_in=55555, port_out=55556)
+        .add(name='my-encoder', image='jinahub/pod.encoder.bigtransferencoder:0.0.6-0.9.33', port_in=55555, port_out=55556)
         .add(name='my-indexer', uses='indexer.yml'))
     ```
     
 - Jina CLI
   - ```bash
-    jina pod --uses jinahub/pod.encoder.bigtransferencoder --port-in 55555 --port-out 55556
+    jina pod --uses jinahub/pod.encoder.bigtransferencoder:0.0.6-0.9.33 --port-in 55555 --port-out 55556
     ```
     
 - Conventional local usage with `uses` argument
@@ -58,8 +58,11 @@ Users can use Pod images in several ways:
   Specify the image name along with the version tag. The snippet below uses Jina version `0.9.20`
   
   -```Dockerfile
-   docker pull jinahub/pod.encoder.bigtransferencoder:0.0.6-0.9.20
+   docker pull jinahub/pod.encoder.bigtransferencoder:0.0.6-0.9.33
    ```
    
-  
+ Note:
+ 
+ One of the limitations with the Hub Executors currently is the tags - all Executor images should have the versions appended in the name i.e.
+ if the version is `0.0.6-0.9.33`, the image name would be `jinahub/pod.encoder.bigtransferencoder:0.0.6-0.9.33`.
    

--- a/encoders/image/BigTransferEncoder/README.md
+++ b/encoders/image/BigTransferEncoder/README.md
@@ -21,7 +21,7 @@ Initialise this Executor specifying parameters i.e.:
 
 The pretrained default path is the result of downloading the models in `download.sh`
 
-### Usage snippet:
+### Snippets:
 
 Initialise BigTransferEncoder:
 

--- a/encoders/image/BigTransferEncoder/README.md
+++ b/encoders/image/BigTransferEncoder/README.md
@@ -1,3 +1,8 @@
 # BigTransferEncoder
 
-`BigTransferEncoder` is Big Transfer (BiT) presented by Google (https://github.com/google-research/big_transfer), this class use pretrained BiT to encode data from a ndarray, potentially B x (Channel x Height x Width) into a ndarray of `B x D`. Internally, :class:`BigTransferEncoder` wraps the models from https://storage.googleapis.com/bit_models/.
+`BigTransferEncoder` is Big Transfer (BiT) presented by Google (https://github.com/google-research/big_transfer), is a State-of-the-art transfer learning model for computer vision. This class uses pretrained BiT to encode data from an `ndarray`, potentially B x (Channel x Height x Width) into an `ndarray` of shape `B x D`. Internally, :class:`BigTransferEncoder` wraps the models from https://storage.googleapis.com/bit_models/.
+Additional links:
+- [Tensorflow Blog](https://blog.tensorflow.org/2020/05/bigtransfer-bit-state-of-art-transfer-learning-computer-vision.html)
+- [Google AI Blog](https://ai.googleblog.com/2020/05/open-sourcing-bit-exploring-large-scale.html)
+- [BiT Research Paper](https://arxiv.org/abs/1912.11370)
+

--- a/encoders/image/BigTransferEncoder/README.md
+++ b/encoders/image/BigTransferEncoder/README.md
@@ -22,6 +22,9 @@ Initialise this Executor specifying parameters i.e.:
 The pretrained default path is the result of downloading the models in `download.sh`
 
 ### Usage snippet:
+
+Initialise BigTransferEncoder:
+
 `BigTransferEncoder(model_path='pretrained', channel_axis=1, metas=metas)`
 
 Users can use Pod images in several ways:

--- a/encoders/image/BigTransferEncoder/manifest.yml
+++ b/encoders/image/BigTransferEncoder/manifest.yml
@@ -6,7 +6,7 @@ description: |
 author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
-documentation: https://github.com/jina-ai/jina-hub
+documentation: https://github.com/jina-ai/jina-hub/blob/master/encoders/image/BigTransferEncoder/README.md
 version: 0.0.6
 license: apache-2.0
 keywords: [Tensorflow, Computer Vision]


### PR DESCRIPTION
`Hub executor documentation`:

- `BiT Encoder`
- Jinahub [jira-373](https://jinaai.atlassian.net/browse/JINAHUBV1-373)