### PR TITLE
fix: add function name param to support RetriBert models

### DIFF
--- a/encoders/nlp/TransformerTorchEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTorchEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.21
+version: 0.0.22
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, pytorch]
 type: pod


### PR DESCRIPTION
**Changes introduced**
Issue from community slack https://jina-ai.slack.com/archives/C0169V26ATY/p1612889881108900

RetriBert models' interface is different to other common models, as their `forward` method does not take `input_ids` as input but expects `input_ids_query` and `input_ids_docs`. 

The functions actually doing the encoding is `embed_questions` and `embed_answers`.

This PR tries to add an extra parameter that allows the change of the function name to be called from the loaded model