### PR TITLE
feat: integrate image metadata in document

### DIFF
--- a/crafters/image/ImageReader/__init__.py
+++ b/crafters/image/ImageReader/__init__.py
@@ -39,4 +39,23 @@ class ImageReader(BaseCrafter):
         img = np.array(raw_img).astype('float32')
         if self.channel_axis != -1:
             img = np.moveaxis(img, -1, self.channel_axis)
-        return dict(weight=1., blob=img)
+        # Add image metadata
+        from PIL.ExifTags import TAGS
+        from PIL.ExifTags import GPSTAGS 
+        # Extract image metadata
+        # https://github.com/python-pillow/Pillow/blob/master/src/PIL/ExifTags.py
+        metadata = {}
+        exif_data = raw_img.getexif()
+        for tag_id in exif_data:
+            tag = TAGS.get(tag_id)
+            if tag is None:
+                tag = GPSTAGS.get(tag_id, tag_id)
+            data = exif_data.get(tag_id)
+            # transform bytes to readable data
+            if isinstance(data, bytes):
+                data = data.decode()
+            # if tag does not exists in Pillow
+            if tag is None:
+                continue
+            metadata[tag] = data
+        return dict(weight=1., blob=img, metadata=metadata)

--- a/crafters/image/ImageReader/manifest.yml
+++ b/crafters/image/ImageReader/manifest.yml
@@ -8,6 +8,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.12
+version: 0.0.13
 license: apache-2.0
 keywords: [Some keywords to describe the executor, separated by commas]

--- a/crafters/image/ImageReader/requirements.txt
+++ b/crafters/image/ImageReader/requirements.txt
@@ -1,1 +1,2 @@
 Pillow==8.1.0
+requests

--- a/crafters/image/ImageReader/tests/test_imagereader.py
+++ b/crafters/image/ImageReader/tests/test_imagereader.py
@@ -34,3 +34,12 @@ def test_io_buffer():
     test_doc = crafter.craft(buffer=image_buffer.getvalue(), uri=None)
     assert test_doc['blob'].shape == (img_size, img_size, 3)
     np.testing.assert_almost_equal(test_doc['blob'], np.array(img).astype('float32'))
+
+
+def test_io_buffer_metadata():
+    crafter = ImageReader()
+    import requests
+    img_url='https://raw.githubusercontent.com/x4nth055/pythoncode-tutorials/master/ethical-hacking/image-metadata-extractor/image.jpg'
+    test_doc = crafter.craft(buffer=None, uri=requests.get(img_url, stream=True).raw)
+    assert test_doc['metadata']['ImageWidth'] == 5312
+    assert test_doc['metadata']['DateTimeOriginal'] == '2016:11:10 19:33:22'


### PR DESCRIPTION
Each image contains textual and numerical information that can be used for searching and can help to have a better ranking. These information are of different aspects like, Geolocation, photogramteric, hardware specification as well as other characteristic information are usually called and saved as metadata. 
For example, if you just want to search for photos that have been shot in Winter, you can get this information from the metadata. If you only want to search for photos shot with a Samsung S20 phone , you can get this information from metadata, or GPS of the photo. All modern digital cameras save this information, some of them even the depth map of the image. 
I think similar relevant  information  can be extracted from audio/video and pdf files. 