### PR TITLE
fix: keras image encoder respects model name

### DIFF
--- a/encoders/image/ImageKerasEncoder/__init__.py
+++ b/encoders/image/ImageKerasEncoder/__init__.py
@@ -37,7 +37,7 @@ class ImageKerasEncoder(BaseTFEncoder):
                 If given other, then ``np.moveaxis(data, channel_axis, -1)`` is performed before :meth:`encode`.
         """
         super().__init__(*args, **kwargs)
-        self.model_name = 'MobileNetV2' or model_name
+        self.model_name = model_name or 'MobileNetV2'
         self.pool_strategy = pool_strategy
         self.img_shape = img_shape
         self.channel_axis = channel_axis

--- a/encoders/image/ImageKerasEncoder/manifest.yml
+++ b/encoders/image/ImageKerasEncoder/manifest.yml
@@ -6,7 +6,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.8
+version: 0.0.9
 license: apache-2.0
 keywords: [Tensorflow, Computer Vision]
 type: pod

--- a/encoders/image/ImageKerasEncoder/tests/test_tfkeras.py
+++ b/encoders/image/ImageKerasEncoder/tests/test_tfkeras.py
@@ -49,3 +49,8 @@ def test_save_and_load_config(encoder):
     encoder_loaded = BaseExecutor.load_config(encoder.config_abspath)
     assert encoder_loaded.channel_axis == encoder.channel_axis
     assert encoder_loaded.pool_strategy == encoder.pool_strategy
+
+
+def test_model_name():
+    encoder = ImageKerasEncoder(model_name='MobileNet')
+    assert encoder.model_name == 'MobileNet'


### PR DESCRIPTION
The `model_name` parameter never worked for the `ImageKerasEncoder`.