### PR TITLE
fix: ranker tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,11 @@
 Jina's one-stop registry for hosting Pods and enabling easy neural search on the cloud
 </p>
 <p align=center>
-<a href="#license"><img src="https://github.com/jina-ai/jina/blob/master/.github/badges/license-badge.svg?raw=true" alt="Jina" title="Jina is licensed under Apache-2.0"></a>
-<a href="https://pypi.org/project/jina/"><img src="https://github.com/jina-ai/jina/blob/master/.github/badges/python-badge.svg?raw=true" alt="Python 3.7 3.8 3.9" title="Jina supports Python 3.7 and above"></a>
-<a href="https://pypi.org/project/jina/"><img src="https://img.shields.io/pypi/v/jina?color=%23099cec&amp;label=PyPI&amp;logo=pypi&amp;logoColor=white" alt="PyPI"></a>
-<a href="https://hub.docker.com/r/jinaai/jina/tags"><img src="https://img.shields.io/docker/v/jinaai/jina?color=%23099cec&amp;label=Docker&amp;logo=docker&amp;logoColor=white&amp;sort=semver" alt="Docker Image Version (latest semver)"></a>
-<a href="https://github.com/jina-ai/jina/actions?query=workflow%3ACI"><img src="https://github.com/jina-ai/jina/workflows/CI/badge.svg" alt="CI"></a>
-<a href="https://github.com/jina-ai/jina/actions?query=workflow%3ACD"><img src="https://github.com/jina-ai/jina/workflows/CD/badge.svg?branch=master" alt="CD"></a>
-<a href="https://codecov.io/gh/jina-ai/jina"><img src="https://codecov.io/gh/jina-ai/jina/branch/master/graph/badge.svg" alt="codecov"></a>
 </p>
 
 Jina Hub is a centralized registry, where you can share and discover custom and community driven Jina Pods and Apps tailored to specific use cases of neural search.
 
-🌌 **Upload and Share Images** - Share your custom Jina Pods by simply uploading a Python file, a Dockerfile, a YAML file, and leave the rest of the work to us. Building and version control is automatically handled on the cloud side.
-
-🌩️ **Cloud Native** - As Jina Hub images are containerized, they can be easily leveraged in any Jina Flow, even in distributed environments.
-
-❤️ **Community Driven** - Hub images are made and owned by the community.
-
-View the existing collection of hub images on [hub.Jina.ai.](https://hub.jina.ai/#/home)
+View the existing collection of hub images on [hub.Jina.ai](https://hub.jina.ai/#/home)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@ Jina's one-stop registry for hosting Pods and enabling easy neural search on the
 <p align=center>
 </p>
 
-Jina Hub is a centralized registry, where you can share and discover custom and community driven Jina Pods and Apps tailored to specific use cases of neural search.
-
-View the existing collection of hub images on [hub.Jina.ai](https://hub.jina.ai/#/home)
-
----
 
 <p align="center">
 <a href="http://docs.jina.ai">Docs</a> • <a href="https://github.com/jina-ai/examples">Examples</a> • <a href="#contributing">Contribute</a> • <a href="https://jobs.jina.ai">Jobs</a> • <a href="http://jina.ai">Website</a> • <a href="http://slack.jina.ai">Slack</a>

--- a/encoders/numeric/CompressionVaeEncoder/__init__.py
+++ b/encoders/numeric/CompressionVaeEncoder/__init__.py
@@ -1,4 +1,4 @@
-__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import os
@@ -15,22 +15,28 @@ from jina.excepts import PretrainedModelFileDoesNotExist
 
 class CompressionVaeEncoder(TFDevice, BaseNumericEncoder):
     """
-    :class:`CompressionVaeEncoder` is a dimensionality reduction tool based on the idea of
-    Variational Autoencoders. It encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`.
+    :class:`CompressionVaeEncoder` is a dimensionality reduction tool.
 
-    Full code and documentation can be found here: https://github.com/maxfrenzel/CompressionVAE..
+    It is based on the idea of Variational Autoencoders.
+    It encodes data from an ndarray in size `B x T` into an ndarray
+    in size `B x D`. Where `B` is the batch's size and `T` and `D`
+    are the dimensions pre (`T`) and after (`D`)the compression.
+
+    Full code and documentation can be found
+    `here <https://github.com/maxfrenzel/CompressionVAE>`_.
+
+    :param model_path: Path to the pretrained model
+    :param args:  Additional positional arguments
+    :param kwargs: Additional keyword arguments
     """
 
     def __init__(self, model_path: Optional[str] = 'model',
                  *args, **kwargs):
-        """
-        :param model_path: specifies the path to the pretrained model
-
-        """
         super().__init__(*args, **kwargs)
         self.model_path = model_path
 
     def post_init(self):
+        """Load VAE model"""
         super().post_init()
         from cvae import cvae
         import cvae.lib.model_iaf as model
@@ -80,8 +86,13 @@ class CompressionVaeEncoder(TFDevice, BaseNumericEncoder):
     @as_ndarray
     def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'np.ndarray':
         """
-        :param data: a `B x T` numpy ``ndarray``, `B` is the size of the batch
-        :return: a `B x D` numpy ``ndarray``
+        Encode data from an ndarray in size `B x T` into an ndarray
+        in size `B x D`.
+
+        :param data: a `B x T` numpy ndarray
+        :return: a `B x D` numpy ndarray
+        :param args:  Additional positional arguments
+        :param kwargs: Additional keyword arguments
         """
         return self.sess.run([self.embeddings],
                              feed_dict={self.data_feature_placeholder: data})[0]

--- a/encoders/numeric/CompressionVaeEncoder/manifest.yml
+++ b/encoders/numeric/CompressionVaeEncoder/manifest.yml
@@ -8,7 +8,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.5
+version: 0.0.6
 license: apache-2.0
-keywords: [Tensorflow,Computer Vision,Variational Autoencoders]
+keywords: [Tensorflow,Computer Vision,Variational Autoencoders, encoder, numeric]
 type: pod

--- a/encoders/numeric/FastICAEncoder/__init__.py
+++ b/encoders/numeric/FastICAEncoder/__init__.py
@@ -1,8 +1,23 @@
+__copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
+__license__ = "Apache-2.0"
+
 from jina.executors.encoders.numeric import TransformEncoder
 
 class FastICAEncoder(TransformEncoder):
     """
-    :class:`FastICAEncoder` encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`.
+    Encodes data using a fast algorithm for Independent Component Analysis (FastICA)
+
+    Encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`.
+    Where `B` is the batch's size and `T` and `D` are the dimensions pre (`T`)
+    and after (`D`) the encoding.
+
+    :param output_dim: Output size.
+    :param num_features: Number of input features. If ``num_features`` is None,
+        ``num_features`` is inferred from the data.
+    :param whiten: If whiten is false, the data is already considered to be whitened,
+        and no whitening is performed.
+    :param args:  Additional positional arguments
+    :param kwargs: Additional keyword arguments
 
     .. note::
         :class:`FastICAEncoder` must be trained before calling ``encode()``.
@@ -10,13 +25,6 @@ class FastICAEncoder(TransformEncoder):
 
     def __init__(self, num_features: int = None, whiten: bool = False,
                  max_iter: int = 200, *args, **kwargs):
-        """
-
-        :param output_dim: the output size.
-        :param num_features: the number of input features.  If ``num_features`` is None, then ``num_features`` is
-            inferred from the data
-        :param whiten: If whiten is false, the data is already considered to be whitened, and no whitening is performed.
-        """
         super().__init__(*args, **kwargs)
         self.whiten = whiten
         self.num_features = num_features
@@ -25,6 +33,7 @@ class FastICAEncoder(TransformEncoder):
         self.model = None
 
     def post_init(self):
+        """Load FastICA model"""
         super().post_init()
         if not self.model:
             from sklearn.decomposition import FastICA
@@ -32,4 +41,3 @@ class FastICAEncoder(TransformEncoder):
                 n_components=self.output_dim,
                 whiten=self.whiten,
                 max_iter=self.max_iter)
-

--- a/encoders/numeric/FastICAEncoder/manifest.yml
+++ b/encoders/numeric/FastICAEncoder/manifest.yml
@@ -8,6 +8,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
-keywords: [encoder, numeric, ica]
+keywords: [encoder, numeric, ica, fastica]

--- a/encoders/numeric/FeatureAgglomerationEncoder/__init__.py
+++ b/encoders/numeric/FeatureAgglomerationEncoder/__init__.py
@@ -1,15 +1,24 @@
-__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 from jina.executors.encoders.numeric import TransformEncoder
 
 class FeatureAgglomerationEncoder(TransformEncoder):
     """
-    :class:`FeatureAgglomerationEncoder` encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`
-    https://scikit-learn.org/stable/modules/generated/sklearn.cluster.FeatureAgglomeration.html
+    Encode data agglomerating features.
+
+    Recursively merges features that minimally increases a given linkage distance.
+    Similar to AgglomerativeClustering, but recursively merges features instead of samples.
+
+    Encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`
+    Where `B` is the batch's size and `T` and `D` are the dimensions pre (`T`)
+    and after (`D`) the encoding.
+
+    See more `at <https://scikit-learn.org/stable/modules/generated/sklearn.cluster.FeatureAgglomeration.html>`_
     """
 
     def post_init(self):
+        """Load FeatureAgglomeration model"""
         super().post_init()
         if not self.model:
             from sklearn.cluster import FeatureAgglomeration

--- a/encoders/numeric/FeatureAgglomerationEncoder/manifest.yml
+++ b/encoders/numeric/FeatureAgglomerationEncoder/manifest.yml
@@ -2,12 +2,14 @@ manifest_version: 1
 name: FeatureAgglomerationEncoder
 kind: encoder
 description: |
-  class:`FeatureAgglomerationEncoder` encodes data from an ndarray in size `B x T` into an ndarray in size `B x D` https://scikit-learn.org/stable/modules/generated/sklearn.cluster.FeatureAgglomeration.html
+  Encode data agglomerating features. Recursively merges features that minimally increases a given linkage distance.
+  Encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`
+  https://scikit-learn.org/stable/modules/generated/sklearn.cluster.FeatureAgglomeration.html
 author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
-keywords: [sklearn.cluster, FeatureAgglomeration]
+keywords: [sklearn.cluster, FeatureAgglomeration, numeric]
 type: pod

--- a/encoders/numeric/IncrementalPCAEncoder/__init__.py
+++ b/encoders/numeric/IncrementalPCAEncoder/__init__.py
@@ -1,25 +1,33 @@
-__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 from jina.executors.encoders.numeric import TransformEncoder
 
 class IncrementalPCAEncoder(TransformEncoder):
     """
-    :class:`IncrementalPCAEncoder` encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`.
+    Encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`.
+
+    Where `B` is the batch's size and `T` and `D` are the dimensions pre (`T`)
+    and after (`D`) the encoding.
+
+    :param output_dim: the output size.
+    :param num_features: the number of input features.
+        If ``num_features`` is None, then ``num_features``
+        is inferred from the data
+    :param whiten: If whiten is false, the data is already considered to be whitened,
+        and no whitening is performed.
+    :param args:  Additional positional arguments
+    :param kwargs: Additional keyword arguments
+
+    More details can be found
+    `here <https://scikit-learn.org/stable/auto_examples/decomposition/plot_incremental_pca.html>`_
 
     .. note::
-        :class:`IncrementalPCAEncoder` must be trained before calling ``encode()``. This encoder can be trained in an
-        incremental way.
+        :class:`IncrementalPCAEncoder` must be trained before calling ``encode()``.
+        This encoder can be trained in an incremental way.
     """
 
     def __init__(self, num_features: int = None, whiten: bool = False, *args, **kwargs):
-        """
-
-        :param output_dim: the output size.
-        :param num_features: the number of input features.  If ``num_features`` is None, then ``num_features`` is
-            inferred from the data
-        :param whiten: If whiten is false, the data is already considered to be whitened, and no whitening is performed.
-        """
         super().__init__(*args, **kwargs)
         self.whiten = whiten
         self.num_features = num_features
@@ -27,6 +35,7 @@ class IncrementalPCAEncoder(TransformEncoder):
         self.model = None
 
     def post_init(self):
+        """Load IncrementalPCA model"""
         super().post_init()
         if not self.model:
             from sklearn.decomposition import IncrementalPCA

--- a/encoders/numeric/IncrementalPCAEncoder/manifest.yml
+++ b/encoders/numeric/IncrementalPCAEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
-keywords: [sklearn, decomposition, IncrementalPCA, pca]
+keywords: [sklearn, decomposition, IncrementalPCA, pca, encoder, numeric]
 type: pod

--- a/encoders/numeric/RandomGaussianEncoder/__init__.py
+++ b/encoders/numeric/RandomGaussianEncoder/__init__.py
@@ -5,11 +5,18 @@ from jina.executors.encoders.numeric import TransformEncoder
 
 class RandomGaussianEncoder(TransformEncoder):
     """
-    :class:`RandomGaussianEncoder` encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`
-    https://scikit-learn.org/stable/modules/generated/sklearn.random_projection.GaussianRandomProjection.html
+    Reduce dimensionality using Gaussian random projection.
+
+    Encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`
+    Where `B` is the batch's size and `T` and `D` are the dimensions pre (`T`)
+    and after (`D`) the encoding.
+
+    More info can be found
+    `here <https://scikit-learn.org/stable/modules/generated/sklearn.random_projection.GaussianRandomProjection.html>`_
     """
 
     def post_init(self):
+        """Load GaussianRandomProjection model"""
         super().post_init()
         if not self.model:
             from sklearn.random_projection import GaussianRandomProjection

--- a/encoders/numeric/RandomGaussianEncoder/manifest.yml
+++ b/encoders/numeric/RandomGaussianEncoder/manifest.yml
@@ -2,12 +2,11 @@ manifest_version: 1
 name: RandomGaussianEncoder
 kind: encoder
 type: pod
-description: RandomGaussianEncoder` encodes data from an ndarray in size `B x T` into
-  an ndarray in size `B x D`
+description: Reduce dimensionality using Gaussian random projection.
 author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.6
+version: 0.0.7
 license: apache-2.0
-keywords: [numeric, sklearn]
+keywords: [numeric, sklearn, numeric, encoder]

--- a/encoders/numeric/RandomSparseEncoder/__init__.py
+++ b/encoders/numeric/RandomSparseEncoder/__init__.py
@@ -1,15 +1,22 @@
-__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 from jina.executors.encoders.numeric import TransformEncoder
 
 class RandomSparseEncoder(TransformEncoder):
     """
-    :class:`RandomSparseEncoder` encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`
-    https://scikit-learn.org/stable/modules/generated/sklearn.random_projection.SparseRandomProjection.html
+    Reduce dimensionality using sparse random projection.
+
+    Encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`
+    Where `B` is the batch's size and `T` and `D` are the dimensions pre (`T`)
+    and after (`D`) the encoding.
+
+    More info can be found
+    `here <https://scikit-learn.org/stable/modules/generated/sklearn.random_projection.SparseRandomProjection.html>`_
     """
 
     def post_init(self):
+        """Load SparseRandomProjection model"""
         super().post_init()
         if not self.model:
             from sklearn.random_projection import SparseRandomProjection

--- a/encoders/numeric/RandomSparseEncoder/manifest.yml
+++ b/encoders/numeric/RandomSparseEncoder/manifest.yml
@@ -1,13 +1,12 @@
 manifest_version: 1
 name: RandomSparseEncoder
 kind: encoder
-description: RandomSparseEncoder encodes data from an ndarray in size `B x T` into
-  an ndarray in size `B x D`
+description: RandomSparseEncoder reduce dimensionality using sparse random projection
 author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.6
+version: 0.0.7
 license: apache-2.0
-keywords: [numeric, sklearn]
+keywords: [numeric, sklearn, encoder]
 type: pod

--- a/encoders/numeric/TSNEEncoder/__init__.py
+++ b/encoders/numeric/TSNEEncoder/__init__.py
@@ -1,4 +1,4 @@
-__copyright__ = "Copyright (c) 2020 Jina AI Limited. All rights reserved."
+__copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 import numpy as np
@@ -9,9 +9,23 @@ from jina.executors.encoders import BaseNumericEncoder
 
 class TSNEEncoder(BaseNumericEncoder):
     """
-    :class:`TSNEEncoder` encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`.
-    https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html
-    TSNE does not inherit Transform encoder because it can't have a transform without fit.
+    Encode data using t-distributed Stochastic Neighbor Embedding.
+
+    Encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`
+    Where `B` is the batch's size and `T` and `D` are the dimensions pre (`T`)
+    and after (`D`) the encoding.
+
+    See more details
+    `here <https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html>`_
+
+    :param output_dim: Dimension of the embedded space
+    :param random_state: Used to seed the cost_function of TSNE
+    :param args:  Additional positional arguments
+    :param kwargs: Additional keyword arguments
+
+    .. note:
+        Unlike other numeric encoders, TSNE does not inherit Transform encoder
+        because it can't have a transform without fit.
     """
 
     def __init__(self, output_dim: int = 64,
@@ -22,6 +36,7 @@ class TSNEEncoder(BaseNumericEncoder):
         self.random_state = random_state
 
     def post_init(self):
+        """Load TSNE model"""
         super().post_init()
         from sklearn.manifold import TSNE
         self.model = TSNE(n_components=self.output_dim, random_state=self.random_state)
@@ -29,7 +44,11 @@ class TSNEEncoder(BaseNumericEncoder):
     @batching
     def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'np.ndarray':
         """
+        Encode data from an ndarray in size `B x T` into an ndarray in size `B x D`
+
         :param data: a `B x T` numpy ``ndarray``, `B` is the size of the batch
         :return: a `B x D` numpy ``ndarray``
+        :param args:  Additional positional arguments
+        :param kwargs: Additional keyword arguments
         """
         return self.model.fit_transform(data)

--- a/encoders/numeric/TSNEEncoder/manifest.yml
+++ b/encoders/numeric/TSNEEncoder/manifest.yml
@@ -1,12 +1,12 @@
 manifest_version: 1
 name: TSNEEncoder
 kind: encoder
-description: Encodes data from an ndarray in size B x T inro an ndarray in size BxD
+description: Encode data using t-distributed Stochastic Neighbor Embedding
 author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.7
+version: 0.0.8
 license: apache-2.0
-keywords: [numeric, sklearn]
+keywords: [numeric, sklearn, encoder, tsne]
 type: pod

--- a/encoders/video/VideoPaddleEncoder/__init__.py
+++ b/encoders/video/VideoPaddleEncoder/__init__.py
@@ -50,6 +50,7 @@ class VideoPaddleEncoder(BasePaddleEncoder):
             raise NotImplementedError(f'unknown pool_strategy: {pool_strategy}')
 
     def post_init(self):
+        """Load VideoPaddleEncoder model"""
         import paddlehub as hub
         module = hub.Module(name=self.model_name)
         inputs, outputs, self.model = module.context(trainable=False)
@@ -64,7 +65,7 @@ class VideoPaddleEncoder(BasePaddleEncoder):
     @as_ndarray
     def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'np.ndarray':
         """
-        Encodes data from a ndarray.
+        Encode data from a ndarray.
 
         Potentially B x T x (Channel x Height x Width) into an ndarray of `B x D`.
 
@@ -88,7 +89,7 @@ class VideoPaddleEncoder(BasePaddleEncoder):
 
     def get_pooling(self, data: 'np.ndarray') -> 'np.ndarray':
         """
-        Get np.ndarray with pooling strategy
+        Get np.ndarray with pooling strategy.
 
         :param data: An np.ndarray of the ``feature_map``
         :return: A `B x D` numpy ``ndarray``, `D` is the output dimension

--- a/encoders/video/VideoPaddleEncoder/manifest.yml
+++ b/encoders/video/VideoPaddleEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.10
+version: 0.0.11
 license: apache-2.0
-keywords: [paddlehub, video]
+keywords: [paddlehub, video, encoder]
 type: pod

--- a/encoders/video/VideoTorchEncoder/__init__.py
+++ b/encoders/video/VideoTorchEncoder/__init__.py
@@ -34,7 +34,6 @@ class VideoTorchEncoder(BaseTorchEncoder, BaseVideoEncoder):
                  channel_axis: int = 1,
                  pool_strategy: str = 'mean',
                  *args, **kwargs):
-        """Set Constructor."""
         super().__init__(*args, **kwargs)
         self.channel_axis = channel_axis
         self.model_name = model_name
@@ -44,6 +43,7 @@ class VideoTorchEncoder(BaseTorchEncoder, BaseVideoEncoder):
         self.pool_strategy = pool_strategy
 
     def post_init(self):
+        """Load Torch model"""
         super().post_init()
         import torchvision.models.video as models
         if self.pool_strategy is not None:
@@ -70,7 +70,7 @@ class VideoTorchEncoder(BaseTorchEncoder, BaseVideoEncoder):
     @as_ndarray
     def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'np.ndarray':
         """
-         Encodes data from a ndarray.
+         Encode data from a ndarray.
 
          :param data: a `B x T x (Channel x Height x Width)` numpy ``ndarray``,
             `B` is the size of the batch, `T` is the number of frames

--- a/encoders/video/VideoTorchEncoder/manifest.yml
+++ b/encoders/video/VideoTorchEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.8
+version: 0.0.9
 license: apache-2.0
-keywords: [torch, video]
+keywords: [torch, video, encoder]
 type: pod

--- a/evaluators/rank/AveragePrecision/__init__.py
+++ b/evaluators/rank/AveragePrecision/__init__.py
@@ -4,8 +4,12 @@ from jina.executors.evaluators.rank import BaseRankingEvaluator
 
 
 class AveragePrecisionEvaluator(BaseRankingEvaluator):
-    """A :class:`AveragePrecisionEvaluator` evaluates the Average Precision of the search.
-       https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Average_precision
+    """
+    Evaluates the Average Precision of the search.
+    https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Average_precision
+
+    :param args:  Additional positional arguments
+    :param kwargs: Additional keyword arguments
     """
 
     def __init__(self, *args, **kwargs):
@@ -13,9 +17,15 @@ class AveragePrecisionEvaluator(BaseRankingEvaluator):
 
     def evaluate(self, actual: Sequence[Any], desired: Sequence[Any], *args, **kwargs) -> float:
         """"
-        :param actual: the matched document identifiers from the request as matched by Indexers and Rankers
-        :param desired: A list of all the relevant IDs. All documents identified in this list are considered to be relevant
-        :return the evaluation metric value for the request document
+        Evaluate the Average Precision of the search.
+
+        :param actual: the matched document identifiers from the request
+            as matched by Indexers and Rankers
+        :param desired: A list of all the relevant IDs. All documents
+            identified in this list are considered to be relevant
+        :return: the evaluation metric value for the request document
+        :param args:  Additional positional arguments
+        :param kwargs: Additional keyword arguments
         """
 
         if len(desired) == 0 or len(actual) == 0:

--- a/evaluators/rank/AveragePrecision/manifest.yml
+++ b/evaluators/rank/AveragePrecision/manifest.yml
@@ -7,7 +7,7 @@ author: Kilian Pfeiffer (kilsen512@gmail.com)
 url: github.com/kilsenp
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub/blob/master/evaluators/rank/AveragePrecision/README.md
-version: 0.0.6
+version: 0.0.7
 license: apache-2.0
 keywords: [evaluator, average precision]
 type: pod

--- a/evaluators/rank/FScoreEvaluator/__init__.py
+++ b/evaluators/rank/FScoreEvaluator/__init__.py
@@ -5,10 +5,13 @@ from jina.executors.evaluators.rank import BaseRankingEvaluator
 
 class FScoreEvaluator(BaseRankingEvaluator):
     """
-    :class:`FScoreEvaluator` Gives the f score of a search system result. (https://en.wikipedia.org/wiki/F-score)
+    Gives the f-score of a search system result.
+    (https://en.wikipedia.org/wiki/F-score)
 
-    :param eval_at: the point at which precision and recall are computed, if None give, will consider all the input to evaluate
-    :param beta: Parameter to weight differently precision and recall. When beta is 1, the fScore corresponds to the harmonic mean
+    :param eval_at: The point at which precision and recall are computed,
+        if ``None`` is given, all input will be considered to evaluate.
+    :param beta: Parameter to weight differently precision and recall.
+        When ``beta` is 1, the fScore corresponds to the harmonic mean
         of precision and recall
     :param args: Additional positional arguments
     :param kwargs: Additional keyword arguments
@@ -22,11 +25,14 @@ class FScoreEvaluator(BaseRankingEvaluator):
 
     def evaluate(self, actual: Sequence[Any], desired: Sequence[Any], *args, **kwargs) -> float:
         """"
-        :param actual: the matched document identifiers from the request as matched by jina indexers and rankers
-        :param desired: the expected documents matches
+        Evaluate the f-score of the search.
+
+        :param actual: The matched document identifiers from the request
+            as matched by jina indexers and rankers
+        :param desired: The expected documents matches
         :param args: Additional positional arguments
         :param kwargs: Additional keyword arguments
-        :return the evaluation metric value for the request document
+        :return: the evaluation metric value for the request document
         """
         if not desired or self.eval_at == 0:
             """TODO: Agree on a behavior"""

--- a/evaluators/rank/FScoreEvaluator/manifest.yml
+++ b/evaluators/rank/FScoreEvaluator/manifest.yml
@@ -2,12 +2,12 @@ manifest_version: 1
 name: FScoreEvaluator
 kind: evaluator
 description: |
-  Gives the FScore between result and groundtruth.
+  Gives the f-score between result and ground truth.
 author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub/blob/master/evaluators/rank/FScoreEvaluator/README.md
-version: 0.0.5
+version: 0.0.6
 license: apache-2.0
 keywords: [evaluator, fScore, f1Score, ranking]
 type: pod

--- a/evaluators/rank/NdcgEvaluator/__init__.py
+++ b/evaluators/rank/NdcgEvaluator/__init__.py
@@ -24,18 +24,27 @@ def _compute_idcg(gains, power_relevance):
 
 class NDCGEvaluator(BaseRankingEvaluator):
     """
-    From a list of sorted retrieved sorted scores and expected scores, evaluates normalized discounted cumulative gain for information retrieval.
-    :param eval_at: The number of documents in each of the lists to consider in the NDCG computation. If None. the complete lists are considered
-        for the evaluation computation
-    :param power_relevance: The power relevance places stronger emphasis on retrieving relevant documents.
-        For detailed information, please check https://en.wikipedia.org/wiki/Discounted_cumulative_gain
-    :param is_relevance_value: boolean indicating if the actual scores are to be considered relevance, meaning highest value is better.
-        If True, the information coming from the actual system results will be sorted in descending order, otherwise in ascending order.
-        Since the `input` of the `evaluate` method is sorted according to the `scores` of both actual and desired input, this parameter is
-        useful for instance when the `matches` come directly from a `VectorIndexer` where score is `distance` and therefore the `smaller` the `better`.
+    From a sorted list of retrieved, scores and scores,
+    evaluates normalized discounted cumulative gain for information retrieval.
+
+    :param eval_at: The number of documents in each of the lists to consider
+        in the NDCG computation. If ``None``is given, the complete lists are
+        considered for the evaluation.
+    :param power_relevance: The power relevance places stronger emphasis on
+        retrieving relevant documents. For detailed information, please check
+        https://en.wikipedia.org/wiki/Discounted_cumulative_gain
+    :param is_relevance_score: Boolean indicating if the actual scores are
+        to be considered relevance. Highest value is better.
+        If True, the information coming from the actual system results will
+        be sorted in descending order, otherwise in ascending order.
+        Since the input of the evaluate method is sorted according to the
+        `scores` of both actual and desired input, this parameter is
+        useful for instance when the ``matches` come directly from a ``VectorIndexer``
+        where score is `distance` and therefore the smaller the better.
 
     .. note:
-        All the IDs that are not found in the groundtruth will be considered to have relevance 0.
+        All the IDs that are not found in the ground truth will be considered to have
+        relevance 0.
     """
 
     def __init__(self,
@@ -54,9 +63,15 @@ class NDCGEvaluator(BaseRankingEvaluator):
             *args, **kwargs
     ) -> float:
         """"
-        :param actual: the tuple of Ids and Scores predicted by the search system. actual will be sorted in descending order
-        :param desired: the expected id, relevance tuples given by user as matching groundtruth.
-        :return the evaluation metric value for the request document.
+        Evaluate normalized discounted cumulative gain for information retrieval.
+
+        :param actual: The tuple of Ids and Scores predicted by the search system.
+            They will be sorted in descending order.
+        :param desired: The expected id and relevance tuples given by user as
+            matching round truth.
+        :param args:  Additional positional arguments
+        :param kwargs: Additional keyword arguments
+        :return: The evaluation metric value for the request document.
         """
         relevances = dict(desired)
         actual_relevances = list(map(lambda x: relevances[x[0]] if x[0] in relevances else 0.,

--- a/evaluators/rank/NdcgEvaluator/manifest.yml
+++ b/evaluators/rank/NdcgEvaluator/manifest.yml
@@ -7,6 +7,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub/blob/master/evaluators/rank/NdcgEvaluator/README.md
-version: 0.0.5
+version: 0.0.6
 license: apache-2.0
 keywords: [ndcg, evaluator, normalized discounted cumulative gain, information retrieval evaluation]

--- a/evaluators/rank/ReciprocalRankEvaluator/__init__.py
+++ b/evaluators/rank/ReciprocalRankEvaluator/__init__.py
@@ -5,7 +5,10 @@ from jina.executors.evaluators.rank import BaseRankingEvaluator
 
 class ReciprocalRankEvaluator(BaseRankingEvaluator):
     """
-    :class:`ReciprocalRankEvaluator` Gives score as per reciprocal rank metric.
+    Gives score as per reciprocal rank metric.
+
+    :param args:  Additional positional arguments
+    :param kwargs: Additional keyword arguments
     """
 
     def __init__(self, *args, **kwargs):
@@ -13,10 +16,14 @@ class ReciprocalRankEvaluator(BaseRankingEvaluator):
 
     def evaluate(self, actual: Sequence[Union[str, int]], desired: Sequence[Union[str, int]], *args, **kwargs) -> float:
         """
-        :param actual: should be a sequence of sorted document IDs.
-        :param desired: It is the sequence of sorted relevant document IDs (the first is the most relevant) and the one to be considered
-            by the algorithm.
-        :return gives reciprocal rank score
+        Evaluate score as per reciprocal rank metric.
+
+        :param actual: Sequence of sorted document IDs.
+        :param desired: Sequence of sorted relevant document IDs
+            (the first is the most relevant) and the one to be considered.
+        :param args:  Additional positional arguments
+        :param kwargs: Additional keyword arguments
+        :return: Reciprocal rank score
         """
         if len(actual) == 0 or len(desired) == 0:
             return 0.0

--- a/evaluators/rank/ReciprocalRankEvaluator/manifest.yml
+++ b/evaluators/rank/ReciprocalRankEvaluator/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub/blob/master/evaluators/rank/NdcgEvaluator/README.md
-version: 0.0.6
+version: 0.0.7
 license: apache-2.0
 keywords: [evaluator, reciprocal rank]
 type: pod

--- a/rankers/BiMatchRanker/__init__.py
+++ b/rankers/BiMatchRanker/__init__.py
@@ -11,7 +11,8 @@ class BiMatchRanker(Chunk2DocRanker):
 
     .. warning:: Here we suppose that the smaller chunk score means the more similar.
     """
-    required_keys = {'length'}
+    query_required_keys = {'length'}
+    match_required_keys = {'length'}
     D_MISS = 2000  # cost of a non-match chunk, used for normalization
 
     def _get_score(self, match_idx, query_chunk_meta, match_chunk_meta, *args, **kwargs):

--- a/rankers/BiMatchRanker/__init__.py
+++ b/rankers/BiMatchRanker/__init__.py
@@ -15,8 +15,8 @@ class BiMatchRanker(Chunk2DocRanker):
     D_MISS = 2000  # cost of a non-match chunk, used for normalization
 
     def _get_score(self, match_idx, query_chunk_meta, match_chunk_meta, *args, **kwargs):
-        s1 = self._directional_score(match_idx, match_chunk_meta, col=self.COL_MATCH_ID)
-        s2 = self._directional_score(match_idx, query_chunk_meta, col=self.COL_DOC_CHUNK_ID)
+        s1 = self._directional_score(match_idx, match_chunk_meta, col=self.COL_DOC_CHUNK_ID)
+        s2 = self._directional_score(match_idx, query_chunk_meta, col=self.COL_QUERY_CHUNK_ID)
         return self.get_doc_id(match_idx), (s1 + s2) / 2.
 
     def _directional_score(self, g, chunk_meta, col):

--- a/rankers/BiMatchRanker/__init__.py
+++ b/rankers/BiMatchRanker/__init__.py
@@ -11,13 +11,12 @@ class BiMatchRanker(Chunk2DocRanker):
 
     .. warning:: Here we suppose that the smaller chunk score means the more similar.
     """
-    query_required_keys = {'length'}
-    match_required_keys = {'length'}
+    required_keys = {'length'}
     D_MISS = 2000  # cost of a non-match chunk, used for normalization
 
     def _get_score(self, match_idx, query_chunk_meta, match_chunk_meta, *args, **kwargs):
-        s1 = self._directional_score(match_idx, match_chunk_meta, col=self.COL_DOC_CHUNK_ID)
-        s2 = self._directional_score(match_idx, query_chunk_meta, col=self.COL_QUERY_CHUNK_ID)
+        s1 = self._directional_score(match_idx, match_chunk_meta, col=self.COL_MATCH_ID)
+        s2 = self._directional_score(match_idx, query_chunk_meta, col=self.COL_DOC_CHUNK_ID)
         return self.get_doc_id(match_idx), (s1 + s2) / 2.
 
     def _directional_score(self, g, chunk_meta, col):

--- a/rankers/BiMatchRanker/manifest.yml
+++ b/rankers/BiMatchRanker/manifest.yml
@@ -6,7 +6,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.10
+version: 0.0.9
 license: apache-2.0
 keywords: [rank, bi-match, naive]
 type: pod

--- a/rankers/BiMatchRanker/manifest.yml
+++ b/rankers/BiMatchRanker/manifest.yml
@@ -6,7 +6,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.9
+version: 0.0.10
 license: apache-2.0
 keywords: [rank, bi-match, naive]
 type: pod

--- a/rankers/BiMatchRanker/tests/test_bimatchranker.py
+++ b/rankers/BiMatchRanker/tests/test_bimatchranker.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from jina.executors.rankers import Chunk2DocRanker
+from jina.executors.rankers import Chunk2DocRanker, COL_STR_TYPE
 
 from .. import BiMatchRanker
 
@@ -26,17 +26,17 @@ def create_data():
             match_chunk_meta[c['id']] = {'length': c['length']}
             match_idx.append((
                 c['parent_id'],
-                c['id'],
-                query_chunk_id,
+                int(c['id']),
+                int(query_chunk_id),
                 c['score'],
             ))
 
     match_idx_numpy = np.array(
         match_idx,
         dtype=[
-            (Chunk2DocRanker.COL_MATCH_PARENT_ID, np.int64),
-            (Chunk2DocRanker.COL_MATCH_ID, np.int64),
+            (Chunk2DocRanker.COL_PARENT_ID, np.int64),
             (Chunk2DocRanker.COL_DOC_CHUNK_ID, np.int64),
+            (Chunk2DocRanker.COL_QUERY_CHUNK_ID, np.int64),
             (Chunk2DocRanker.COL_SCORE, np.float64)
         ]
     )
@@ -49,7 +49,7 @@ def test_bimatchranker():
     doc_idx = ranker.score(match_idx, query_chunk_meta, match_chunk_meta)
     # check the matched docs are in descending order of the scores
     assert doc_idx[0][1] > doc_idx[1][1]
-    assert doc_idx[1][0] == 4294967294
-    assert doc_idx[0][0] == 1
+    assert doc_idx[1][0] == '4294967294'
+    assert doc_idx[0][0] == '1'
     # check the number of matched docs
     assert len(doc_idx) == 2

--- a/rankers/BiMatchRanker/tests/test_bimatchranker.py
+++ b/rankers/BiMatchRanker/tests/test_bimatchranker.py
@@ -26,8 +26,8 @@ def create_data():
             match_chunk_meta[c['id']] = {'length': c['length']}
             match_idx.append((
                 c['parent_id'],
-                int(c['id']),
-                int(query_chunk_id),
+                c['id'],
+                query_chunk_id,
                 c['score'],
             ))
 

--- a/rankers/BiMatchRanker/tests/test_bimatchranker.py
+++ b/rankers/BiMatchRanker/tests/test_bimatchranker.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from jina.executors.rankers import Chunk2DocRanker, COL_STR_TYPE
+from jina.executors.rankers import Chunk2DocRanker
 
 from .. import BiMatchRanker
 
@@ -34,9 +34,9 @@ def create_data():
     match_idx_numpy = np.array(
         match_idx,
         dtype=[
-            (Chunk2DocRanker.COL_PARENT_ID, np.int64),
+            (Chunk2DocRanker.COL_MATCH_PARENT_ID, np.int64),
+            (Chunk2DocRanker.COL_MATCH_ID, np.int64),
             (Chunk2DocRanker.COL_DOC_CHUNK_ID, np.int64),
-            (Chunk2DocRanker.COL_QUERY_CHUNK_ID, np.int64),
             (Chunk2DocRanker.COL_SCORE, np.float64)
         ]
     )
@@ -49,7 +49,7 @@ def test_bimatchranker():
     doc_idx = ranker.score(match_idx, query_chunk_meta, match_chunk_meta)
     # check the matched docs are in descending order of the scores
     assert doc_idx[0][1] > doc_idx[1][1]
-    assert doc_idx[1][0] == '4294967294'
-    assert doc_idx[0][0] == '1'
+    assert doc_idx[1][0] == 4294967294
+    assert doc_idx[0][0] == 1
     # check the number of matched docs
     assert len(doc_idx) == 2

--- a/rankers/SimpleAggregateRanker/config.yml
+++ b/rankers/SimpleAggregateRanker/config.yml
@@ -1,7 +1,7 @@
 !SimpleAggregateRanker
 with:
   aggregate_function: min
-  is_reversed_score: True
+  inverse_score: True
 metas:
   py_modules:
     # - you can put more dependencies here

--- a/rankers/SimpleAggregateRanker/config.yml
+++ b/rankers/SimpleAggregateRanker/config.yml
@@ -1,7 +1,7 @@
 !SimpleAggregateRanker
 with:
-  aggregate_function: min
-  inverse_score: True
+  aggregate_function: 'min'
+  inverse_score: true
 metas:
   py_modules:
     # - you can put more dependencies here

--- a/rankers/SimpleAggregateRanker/config.yml
+++ b/rankers/SimpleAggregateRanker/config.yml
@@ -1,6 +1,6 @@
 !SimpleAggregateRanker
 with:
-  aggregate_function: 'min'
+  aggregate_function: min
   inverse_score: true
 metas:
   py_modules:

--- a/rankers/SimpleAggregateRanker/manifest.yml
+++ b/rankers/SimpleAggregateRanker/manifest.yml
@@ -9,6 +9,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.11
+version: 0.0.12
 license: apache-2.0
 keywords: [ranker, aggregation]


### PR DESCRIPTION
This Pr includes changes of https://github.com/jina-ai/jina-hub/pull/4144, so will close https://github.com/jina-ai/jina-hub/pull/4144

There's `ZEDRuntime@83[C]:can not load the executor from rankers/SimpleAggregateRanker/config.yml.` in hub-build-test ci. 
And in previous prs, and every other pr it also exists.