### PR TITLE
docs: fix transformer docstrings

### DIFF
--- a/encoders/nlp/TransformerTFEncoder/__init__.py
+++ b/encoders/nlp/TransformerTFEncoder/__init__.py
@@ -65,7 +65,7 @@ class TransformerTFEncoder(TFDevice, BaseEncoder):
             raise NotImplementedError
 
     def post_init(self):
-        """Load TF model"""
+        """Load the transformer model and encoder"""
         from transformers import TFAutoModel, AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(self.base_tokenizer_model)
@@ -78,9 +78,8 @@ class TransformerTFEncoder(TFDevice, BaseEncoder):
     @as_ndarray
     def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'np.ndarray':
         """
-        Encode an array of string in size `B` into an ndarray in size `B x D`
-
-        The ndarray potentially is BatchSize x (Channel x Height x Width)
+        Encode an array of string in size `B` into an ndarray in size `B x D`,
+        where `B` is the batch size and `D` is the dimensionality of the encoding.
 
         :param data: a 1d array of string type in size `B`
         :return: an ndarray in size `B x D`

--- a/encoders/nlp/TransformerTFEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTFEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.18
+version: 0.0.19
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, tensorflow]
 type: pod

--- a/encoders/nlp/TransformerTorchEncoder/__init__.py
+++ b/encoders/nlp/TransformerTorchEncoder/__init__.py
@@ -87,7 +87,7 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
             raise NotImplementedError
 
     def post_init(self):
-        """Load Torch model"""
+        """Load the transformer model and encoder"""
         import torch
         from transformers import AutoModel, AutoTokenizer
 
@@ -116,9 +116,8 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
     @as_ndarray
     def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'np.ndarray':
         """
-        Encode an array of string in size `B` into an ndarray in size `B x D`
-
-        The ndarray potentially is BatchSize x (Channel x Height x Width)
+        Encode an array of string in size `B` into an ndarray in size `B x D`,
+        where `B` is the batch size and `D` is the dimensionality of the encoding.
 
         :param data: a 1d array of string type in size `B`
         :return: an ndarray in size `B x D` with the embeddings

--- a/encoders/nlp/TransformerTorchEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTorchEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.23
+version: 0.0.24
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, pytorch]
 type: pod


### PR DESCRIPTION
This improves the transformer docstrings, better explaining the dimensionality of inputs (as prev. docstring seems to refer to image dimensions)