### PR TITLE
fix: bimatchranker passing param

### DIFF
--- a/rankers/BiMatchRanker/__init__.py
+++ b/rankers/BiMatchRanker/__init__.py
@@ -59,7 +59,7 @@ class BiMatchRanker(Chunk2DocRanker):
     """
 
     def __init__(self, d_miss: Optional[Union[int, float]] = None, *args, **kwargs):
-        super().__init__(('length', ), ('length', ), *args, **kwargs)
+        super().__init__(query_required_keys=('length', ), match_required_keys=('length', ), *args, **kwargs)
         self.d_miss = d_miss or 2000
 
     def _get_score(self, match_idx: 'np.ndarray', query_chunk_meta: Dict, match_chunk_meta: Dict, *args, **kwargs):

--- a/rankers/BiMatchRanker/__init__.py
+++ b/rankers/BiMatchRanker/__init__.py
@@ -51,6 +51,8 @@ class BiMatchRanker(Chunk2DocRanker):
 
     So for every `Document`, a score is computed adding some penalty to the `missing` in both perspectives.
 
+    :param query_required_keys: requested fields for query
+    :param match_required_keys: requested fields for match
     :param d_miss: Cost associated to a miss chunk
     :param args:  Additional positional arguments
     :param kwargs: Additional keyword arguments

--- a/rankers/BiMatchRanker/__init__.py
+++ b/rankers/BiMatchRanker/__init__.py
@@ -58,9 +58,6 @@ class BiMatchRanker(Chunk2DocRanker):
     .. warning:: Here we suppose that the smaller chunk score means the more similar.
     """
 
-    # query_required_keys = ('length', )
-    # match_required_keys = ('length', )
-
     def __init__(self, query_required_keys: Optional = ('length',), match_required_keys: Optional = ('length',),
                  d_miss: Optional[Union[int, float]] = None, *args, **kwargs):
         super().__init__(query_required_keys, match_required_keys, *args, **kwargs)

--- a/rankers/BiMatchRanker/__init__.py
+++ b/rankers/BiMatchRanker/__init__.py
@@ -51,8 +51,6 @@ class BiMatchRanker(Chunk2DocRanker):
 
     So for every `Document`, a score is computed adding some penalty to the `missing` in both perspectives.
 
-    :param query_required_keys: requested fields for query
-    :param match_required_keys: requested fields for match
     :param d_miss: Cost associated to a miss chunk
     :param args:  Additional positional arguments
     :param kwargs: Additional keyword arguments
@@ -60,9 +58,8 @@ class BiMatchRanker(Chunk2DocRanker):
     .. warning:: Here we suppose that the smaller chunk score means the more similar.
     """
 
-    def __init__(self, query_required_keys: Optional = ('length',), match_required_keys: Optional = ('length',),
-                 d_miss: Optional[Union[int, float]] = None, *args, **kwargs):
-        super().__init__(query_required_keys, match_required_keys, *args, **kwargs)
+    def __init__(self, d_miss: Optional[Union[int, float]] = None, *args, **kwargs):
+        super().__init__(('length', ), ('length', ), *args, **kwargs)
         self.d_miss = d_miss or 2000
 
     def _get_score(self, match_idx: 'np.ndarray', query_chunk_meta: Dict, match_chunk_meta: Dict, *args, **kwargs):

--- a/rankers/BiMatchRanker/__init__.py
+++ b/rankers/BiMatchRanker/__init__.py
@@ -4,7 +4,6 @@ __license__ = "Apache-2.0"
 from typing import Dict, Union, Optional
 
 import numpy as np
-
 from jina.executors.rankers import Chunk2DocRanker
 
 
@@ -58,11 +57,13 @@ class BiMatchRanker(Chunk2DocRanker):
 
     .. warning:: Here we suppose that the smaller chunk score means the more similar.
     """
-    query_required_keys = ('length', )
-    match_required_keys = ('length', )
 
-    def __init__(self, d_miss: Optional[Union[int, float]] = None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    # query_required_keys = ('length', )
+    # match_required_keys = ('length', )
+
+    def __init__(self, query_required_keys: Optional = ('length',), match_required_keys: Optional = ('length',),
+                 d_miss: Optional[Union[int, float]] = None, *args, **kwargs):
+        super().__init__(query_required_keys, match_required_keys, *args, **kwargs)
         self.d_miss = d_miss or 2000
 
     def _get_score(self, match_idx: 'np.ndarray', query_chunk_meta: Dict, match_chunk_meta: Dict, *args, **kwargs):

--- a/rankers/BiMatchRanker/manifest.yml
+++ b/rankers/BiMatchRanker/manifest.yml
@@ -6,7 +6,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub/blob/master/rankers/BiMatchRanker/README.md
-version: 0.0.10
+version: 0.0.11
 license: apache-2.0
 keywords: [rank, bi-match, naive]
 type: pod


### PR DESCRIPTION
Caused by https://github.com/jina-ai/jina/pull/1947
Several ways to solve this issue. Not sure which is the best. This issue caused the error of Tumblr-search.

1. See this PR
2. ` query_required_keys = ('length', )
       match_required_keys = ('length', )

    def __init__(self, d_miss: Optional[Union[int, float]] = None, *args, **kwargs):
        super().__init__(self.query_required_keys, self. match_required_keys, *args, **kwargs)`
