### PR TITLE
fix: faiss indexer inner_product returns sim and not distance (#3524)

### DIFF
--- a/indexers/vector/FaissIndexer/__init__.py
+++ b/indexers/vector/FaissIndexer/__init__.py
@@ -130,6 +130,9 @@ class FaissIndexer(FaissDevice, BaseNumpyIndexer):
             from faiss import normalize_L2
             normalize_L2(vecs)
         dist, ids = self.query_handler.search(vecs, top_k)
+        if self.distance == 'inner_product':
+            self.logger.warning('inner_product will be output as distance.')
+            dist = np.abs(dist - 1)
         keys = self._int2ext_id[self.valid_indices][ids]
         return keys, dist
 

--- a/indexers/vector/FaissIndexer/__init__.py
+++ b/indexers/vector/FaissIndexer/__init__.py
@@ -82,6 +82,7 @@ class FaissIndexer(FaissDevice, BaseNumpyIndexer):
 
         metric = faiss.METRIC_L2
         if self.distance == 'inner_product':
+            self.logger.warning('inner_product will be output as distance instead of similarity.')
             metric = faiss.METRIC_INNER_PRODUCT
         if self.distance not in {'inner_product', 'l2'}:
             self.logger.warning('Invalid distance metric for Faiss index construction. Defaulting to l2 distance')
@@ -131,8 +132,7 @@ class FaissIndexer(FaissDevice, BaseNumpyIndexer):
             normalize_L2(vecs)
         dist, ids = self.query_handler.search(vecs, top_k)
         if self.distance == 'inner_product':
-            self.logger.warning('inner_product will be output as distance.')
-            dist = np.abs(dist - 1)
+            dist = 1 - dist
         keys = self._int2ext_id[self.valid_indices][ids]
         return keys, dist
 

--- a/indexers/vector/FaissIndexer/manifest.yml
+++ b/indexers/vector/FaissIndexer/manifest.yml
@@ -7,6 +7,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.15
+version: 0.0.16
 license: apache-2.0
 keywords: [vector, faiss, indexer, ANN]

--- a/indexers/vector/FaissIndexer/tests/test_faissindexer.py
+++ b/indexers/vector/FaissIndexer/tests/test_faissindexer.py
@@ -252,5 +252,4 @@ def test_faiss_normalization(metas, distance):
         query = np.zeros((1, num_dims))
         query[0, 0] = 5
         idx, dist = indexer.query(query.astype('float32'), top_k=2)
-        expected_dist = 1 if distance == 'inner_product' else 0
-        assert dist[0, 0] == expected_dist
+        assert dist[0, 0] == 0


### PR DESCRIPTION
Hi there,
in this fix results of query in a Faiss index will be always as top-k vector with smallest metric, so in ascending order.
The problem in this issue was specific on inner_product that returns similarity and not distances.