### PR TITLE
docs: fix readme to create a hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ with Flow().add(uses='docker://' + my_image_tag):
 ### Prerequisites
 
 - Install [Docker](https://docs.docker.com/get-docker/).
-- `pip install "jina[hub]"`
+- `pip install "jina[devel]"`
 
 ### 📦 Create a new Executor
 


### PR DESCRIPTION
### Do I need `-devel`?

Use `-devel` image, if you want to:
- have efficiency improvement on AsyncIO and data compression
- enable prettified error printing
- **build Jina Hub extension**
- expose REST interface beyond gRPC
- enable log-streaming/aggregating via `fluentd`
- enable mime-type sniffing