### PR TITLE
feat: fix sentencizer on other languages

### DIFF
--- a/segmenters/nlp/Sentencizer/__init__.py
+++ b/segmenters/nlp/Sentencizer/__init__.py
@@ -47,11 +47,12 @@ class Sentencizer(BaseSegmenter):
                 self.min_sent_len, self.max_sent_len))
         self._slit_pat = re.compile('\s*([^{0}]+)(?<!\s)[{0}]*'.format(''.join(set(self.punct_chars))))
 
-    def segment(self, text: str, *args, **kwargs) -> List[Dict]:
+    def segment(self, text: str, lang="en", *args, **kwargs) -> List[Dict]:
         """
         Split the text into sentences.
 
         :param text: the raw text
+        :param lang: language of text, default is english
         :return: a list of chunk dicts with the split sentences
         :param args:  Additional positional arguments
         :param kwargs: Additional keyword arguments
@@ -63,7 +64,7 @@ class Sentencizer(BaseSegmenter):
         if not ret:
             ret = [(text, 0, len(text))]
         for ci, (r, s, e) in enumerate(ret):
-            f = ''.join(filter(lambda x: x in string.printable, r))
+            f = ''.join(filter(lambda x: x in string.printable, r)) if lang == "en" else r
             f = re.sub('\n+', ' ', f).strip()
             f = f[:self.max_sent_len]
             if len(f) > self.min_sent_len:

--- a/segmenters/nlp/Sentencizer/__init__.py
+++ b/segmenters/nlp/Sentencizer/__init__.py
@@ -22,6 +22,7 @@ class Sentencizer(BaseSegmenter):
         for example ['!', '.', '?'] will use '!', '.' and '?'
     :param uniform_weight: the definition of it should have
         uniform weight or should be calculated
+    :param lang: the language of text to be segmented
     :param args:  Additional positional arguments
     :param kwargs: Additional keyword arguments
 
@@ -32,6 +33,7 @@ class Sentencizer(BaseSegmenter):
                  max_sent_len: int = 512,
                  punct_chars: Optional[List[str]] = None,
                  uniform_weight: bool = True,
+                 lang: Optional[str] = 'en',
                  *args, **kwargs):
         """Set constructor."""
         super().__init__(*args, **kwargs)
@@ -39,6 +41,7 @@ class Sentencizer(BaseSegmenter):
         self.max_sent_len = max_sent_len
         self.punct_chars = punct_chars
         self.uniform_weight = uniform_weight
+        self.lang = lang
         if not punct_chars:
             self.punct_chars = ['!', '.', '?', '։', '؟', '۔', '܀', '܁', '܂', '‼', '‽', '⁇', '⁈', '⁉', '⸮', '﹖', '﹗',
                                 '！', '．', '？', '｡', '。', '\n']
@@ -47,12 +50,11 @@ class Sentencizer(BaseSegmenter):
                 self.min_sent_len, self.max_sent_len))
         self._slit_pat = re.compile('\s*([^{0}]+)(?<!\s)[{0}]*'.format(''.join(set(self.punct_chars))))
 
-    def segment(self, text: str, lang="en", *args, **kwargs) -> List[Dict]:
+    def segment(self, text: str, *args, **kwargs) -> List[Dict]:
         """
         Split the text into sentences.
 
         :param text: the raw text
-        :param lang: language of text, default is english
         :return: a list of chunk dicts with the split sentences
         :param args:  Additional positional arguments
         :param kwargs: Additional keyword arguments
@@ -64,7 +66,7 @@ class Sentencizer(BaseSegmenter):
         if not ret:
             ret = [(text, 0, len(text))]
         for ci, (r, s, e) in enumerate(ret):
-            f = ''.join(filter(lambda x: x in string.printable, r)) if lang == "en" else r
+            f = ''.join(filter(lambda x: x in string.printable, r)) if self.lang == 'en' else r
             f = re.sub('\n+', ' ', f).strip()
             f = f[:self.max_sent_len]
             if len(f) > self.min_sent_len:

--- a/segmenters/nlp/Sentencizer/__init__.py
+++ b/segmenters/nlp/Sentencizer/__init__.py
@@ -22,7 +22,6 @@ class Sentencizer(BaseSegmenter):
         for example ['!', '.', '?'] will use '!', '.' and '?'
     :param uniform_weight: the definition of it should have
         uniform weight or should be calculated
-    :param lang: the language of text to be segmented
     :param args:  Additional positional arguments
     :param kwargs: Additional keyword arguments
 
@@ -33,7 +32,6 @@ class Sentencizer(BaseSegmenter):
                  max_sent_len: int = 512,
                  punct_chars: Optional[List[str]] = None,
                  uniform_weight: bool = True,
-                 lang: Optional[str] = 'en',
                  *args, **kwargs):
         """Set constructor."""
         super().__init__(*args, **kwargs)
@@ -41,7 +39,6 @@ class Sentencizer(BaseSegmenter):
         self.max_sent_len = max_sent_len
         self.punct_chars = punct_chars
         self.uniform_weight = uniform_weight
-        self.lang = lang
         if not punct_chars:
             self.punct_chars = ['!', '.', '?', '։', '؟', '۔', '܀', '܁', '܂', '‼', '‽', '⁇', '⁈', '⁉', '⸮', '﹖', '﹗',
                                 '！', '．', '？', '｡', '。', '\n']
@@ -66,8 +63,7 @@ class Sentencizer(BaseSegmenter):
         if not ret:
             ret = [(text, 0, len(text))]
         for ci, (r, s, e) in enumerate(ret):
-            f = ''.join(filter(lambda x: x in string.printable, r)) if self.lang == 'en' else r
-            f = re.sub('\n+', ' ', f).strip()
+            f = re.sub('\n+', ' ', r).strip()
             f = f[:self.max_sent_len]
             if len(f) > self.min_sent_len:
                 results.append(dict(

--- a/segmenters/nlp/Sentencizer/manifest.yml
+++ b/segmenters/nlp/Sentencizer/manifest.yml
@@ -8,6 +8,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub/blob/master/segmenters/nlp/Sentencizer/README.md
-version: 0.0.10
+version: 0.0.11
 license: apache-2.0
 keywords: [text, nlp, segment]

--- a/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
+++ b/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
@@ -6,7 +6,7 @@ from .. import Sentencizer
 def test_sentencier_en():
     sentencizer = Sentencizer()
     text = 'It is a sunny day!!!! When Andy comes back, we are going to the zoo.'
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 2
 
 
@@ -17,7 +17,7 @@ def test_sentencier_en_new_lines():
     sentencizer = Sentencizer()
     text = 'It is a sunny day!!!! When Andy comes back,\n' \
            'we are going to the zoo.'
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 3
 
 
@@ -29,7 +29,7 @@ def test_sentencier_en_float_numbers():
     sentencizer = Sentencizer()
     text = 'With a 0.99 probability this sentence will be ' \
            'tokenized in 2 sentences.'
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 2
 
 
@@ -41,8 +41,8 @@ def test_sentencier_en_trim_spaces():
     """
     sentencizer = Sentencizer()
     text = '  This ,  text is...  . Amazing !!'
-    chunks = [i['text'] for i in sentencizer.segment(text, 0)]
-    locs = [i['location'] for i in sentencizer.segment(text, 0)]
+    chunks = [i['text'] for i in sentencizer.segment(text)]
+    locs = [i['location'] for i in sentencizer.segment(text)]
     assert chunks, ["This ,  text is..." == "Amazing"]
     assert text[locs[0][0]:locs[0][1]], '  This  ==   text is...'
     assert text[locs[1][0]:locs[1][1]] == ' Amazing'
@@ -57,8 +57,38 @@ def test_sentencier_en_trim_spaces():
 
 
 def test_sentencier_cn():
+    """
+    Sentencizer does not work for chinese,
+    because string.printable does not contain Chinese characters.
+    """
     sentencizer = Sentencizer()
     text = '今天是个大晴天！安迪回来以后，我们准备去动物园。'
-    crafted_chunk_list = sentencizer.segment(text, 0)
-    # Sentencizer does not work for chinese because string.printable does not contain Chinese characters
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 0
+
+
+def test_sentencier_cn_lang():
+    """
+    If we indicate the text is not in english,
+    sentencizer should be able to skip string.printable and work for chinese.
+    """
+    sentencizer = Sentencizer()
+    text = '今天又是个大晴天！安迪回来以后，我们准备再去一次动物园！'
+    crafted_chunk_list = sentencizer.segment(text, "cn")
+    assert len(crafted_chunk_list) == 2
+
+
+def test_sentencier_en_lang():
+    """
+    Make sure sentencizer still apply filter on english texts
+    when language is set to "en" or use default value.
+    And will not apply filter if set lang to something else.
+    """
+    sentencizer = Sentencizer()
+    text = 'It is a sunny day again Ää!!!! When Andy comes back, we are going to the zoo one more time!'
+    chunks = [i['text'] for i in sentencizer.segment(text, "en")]
+    chunks_no_lang = [i['text'] for i in sentencizer.segment(text)]
+    chunks_deu = [i['text'] for i in sentencizer.segment(text, "deu")]
+    assert chunks[0] == chunks_no_lang[0] == "It is a sunny day again !!!!"
+    assert chunks_deu[0] == "It is a sunny day again Ää!!!!"
+    assert len(chunks) == len(chunks_no_lang) == len(chunks_deu) == 2

--- a/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
+++ b/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
@@ -57,21 +57,33 @@ def test_sentencizer_en_trim_spaces():
         f.index_lines(['  This ,  text is...  . Amazing !!'], on_done=validate, callback_on_body=True, line_format='csv')
 
 @pytest.mark.parametrize(
-    'expected_len, expected_text, sentence',
-    [(2, 'إنه يوم مشمس!!!!', 'إنه يوم مشمس!!!! عندما يعود آندي ، سنذهب إلى حديقة الحيوانات.'),
-     (2, '今天是个大晴天！！！！', '今天是个大晴天！！！！安迪回来以后，我们准备去动物园。'),
-     (2, 'Het is een zonnige dag!!!!', 'Het is een zonnige dag!!!! Als Andy terugkomt, gaan we naar de dierentuin.'),
-     (2, "C'est une journée ensoleillée!!!!", "C'est une journée ensoleillée!!!! Quand Andy revient, nous allons au zoo."),
-     (2, 'Es ist ein sonniger Tag!!!!', 'Es ist ein sonniger Tag!!!! Wenn Andy zurückkommt, gehen wir in den Zoo.'),
-     (2, 'यह एक धूपवाला दिन है!!!!', 'यह एक धूपवाला दिन है!!!! जब एंडी वापस आता है, हम चिड़ियाघर जा रहे हैं।'),
-     (2, '晴れた日です!!!!', '晴れた日です!!!!アンディが戻ってきたら、動物園に行きます。'),
-     (2, '화창한 날입니다!!!!', '화창한 날입니다!!!! Andy가 돌아 오면 우리는 동물원에갑니다.'),
-     (2, 'É um dia ensolarado!!!!', 'É um dia ensolarado!!!! Quando Andy voltar, vamos ao zoológico.'),
-     (2, 'Это солнечный день!!!!', 'Это солнечный день!!!! Когда Энди вернется, мы идем в зоопарк.'),
-     (2, '¡¡¡¡Es un día soleado!!!!', '¡¡¡¡Es un día soleado!!!! Cuando Andy regrese, iremos al zoológico.'),
-     (2, 'It is ä suñny dáy!!!!', 'It is ä suñny dáy!!!! When Andy comes back, we are going to the 动物园!')],
+    'expected_len, expected_first_chunk, expected_second_chunk, sentence',
+    [(2, 'إنه يوم مشمس!!!!', 'عندما يعود آندي ، سنذهب إلى حديقة الحيوانات.',
+         'إنه يوم مشمس!!!! عندما يعود آندي ، سنذهب إلى حديقة الحيوانات.'),
+     (2, '今天是个大晴天！！！！', '安迪回来以后，我们准备去动物园。',
+         '今天是个大晴天！！！！安迪回来以后，我们准备去动物园。'),
+     (2, 'Het is een zonnige dag!!!!', 'Als Andy terugkomt, gaan we naar de dierentuin.',
+         'Het is een zonnige dag!!!! Als Andy terugkomt, gaan we naar de dierentuin.'),
+     (2, "C'est une journée ensoleillée!!!!", "Quand Andy revient, nous allons au zoo.",
+         "C'est une journée ensoleillée!!!! Quand Andy revient, nous allons au zoo."),
+     (2, 'Es ist ein sonniger Tag!!!!', 'Wenn Andy zurückkommt, gehen wir in den Zoo.',
+         'Es ist ein sonniger Tag!!!! Wenn Andy zurückkommt, gehen wir in den Zoo.'),
+     (2, 'यह एक धूपवाला दिन है!!!!', 'जब एंडी वापस आता है, हम चिड़ियाघर जा रहे हैं।',
+         'यह एक धूपवाला दिन है!!!! जब एंडी वापस आता है, हम चिड़ियाघर जा रहे हैं।'),
+     (2, '晴れた日です!!!!', 'アンディが戻ってきたら、動物園に行きます。',
+         '晴れた日です!!!!アンディが戻ってきたら、動物園に行きます。'),
+     (2, '화창한 날입니다!!!!', 'Andy가 돌아 오면 우리는 동물원에갑니다.',
+         '화창한 날입니다!!!! Andy가 돌아 오면 우리는 동물원에갑니다.'),
+     (2, 'É um dia ensolarado!!!!', 'Quando Andy voltar, vamos ao zoológico.',
+         'É um dia ensolarado!!!! Quando Andy voltar, vamos ao zoológico.'),
+     (2, 'Это солнечный день!!!!', 'Когда Энди вернется, мы идем в зоопарк.',
+         'Это солнечный день!!!! Когда Энди вернется, мы идем в зоопарк.'),
+     (2, '¡¡¡¡Es un día soleado!!!!', 'Cuando Andy regrese, iremos al zoológico.',
+         '¡¡¡¡Es un día soleado!!!! Cuando Andy regrese, iremos al zoológico.'),
+     (2, 'It is ä suñny dáy!!!!', 'When Andy comes back, we are going to the 动物园!',
+         'It is ä suñny dáy!!!! When Andy comes back, we are going to the 动物园!')],
 )
-def test_sentencizer_multi_lang(expected_len, expected_text, sentence):
+def test_sentencizer_multi_lang(expected_len, expected_first_chunk, expected_second_chunk, sentence):
     """
     Test multiple scenarios with various languages
     """
@@ -79,5 +91,5 @@ def test_sentencizer_multi_lang(expected_len, expected_text, sentence):
     segmented = sentencizer.segment(sentence)
     chunks = [i['text'] for i in segmented]
     assert len(segmented) == expected_len
-    if (expected_len != 0):
-        assert chunks[0] == expected_text
+    assert chunks[0] == expected_first_chunk
+    assert chunks[1] == expected_second_chunk

--- a/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
+++ b/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
@@ -7,7 +7,7 @@ import pytest
 def test_sentencizer_en():
     sentencizer = Sentencizer()
     text = 'It is a sunny day!!!! When Andy comes back, we are going to the zoo.'
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 2
 
 
@@ -18,7 +18,7 @@ def test_sentencizer_en_new_lines():
     sentencizer = Sentencizer()
     text = 'It is a sunny day!!!! When Andy comes back,\n' \
            'we are going to the zoo.'
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 3
 
 
@@ -30,7 +30,7 @@ def test_sentencizer_en_float_numbers():
     sentencizer = Sentencizer()
     text = 'With a 0.99 probability this sentence will be ' \
            'tokenized in 2 sentences.'
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 2
 
 
@@ -42,8 +42,8 @@ def test_sentencizer_en_trim_spaces():
     """
     sentencizer = Sentencizer()
     text = '  This ,  text is...  . Amazing !!'
-    chunks = [i['text'] for i in sentencizer.segment(text, 0)]
-    locs = [i['location'] for i in sentencizer.segment(text, 0)]
+    chunks = [i['text'] for i in sentencizer.segment(text)]
+    locs = [i['location'] for i in sentencizer.segment(text)]
     assert chunks, ["This ,  text is..." == "Amazing"]
     assert text[locs[0][0]:locs[0][1]], '  This  ==   text is...'
     assert text[locs[1][0]:locs[1][1]] == ' Amazing'
@@ -57,23 +57,39 @@ def test_sentencizer_en_trim_spaces():
         f.index_lines(['  This ,  text is...  . Amazing !!'], on_done=validate, callback_on_body=True, line_format='csv')
 
 
-chinese_sentence = '今天是个大晴天！安迪回来以后，我们准备去动物园。'
-mixed_sentence = 'It is a sunny day again Ää!!!! When Andy comes back, we are going to the 动物园 one more time!'
+arabic_sentence = 'إنه يوم مشمس!!!! عندما يعود آندي ، سنذهب إلى حديقة الحيوانات.'
+chinese_sentence = '今天是个大晴天！！！！安迪回来以后，我们准备去动物园。'
+dutch_sentence = 'Het is een zonnige dag!!!! Als Andy terugkomt, gaan we naar de dierentuin.'
+french_sentence = "C'est une journée ensoleillée!!!! Quand Andy revient, nous allons au zoo."
+german_sentence = 'Es ist ein sonniger Tag!!!! Wenn Andy zurückkommt, gehen wir in den Zoo.'
+hindi_sentence = 'यह एक धूपवाला दिन है!!!! जब एंडी वापस आता है, हम चिड़ियाघर जा रहे हैं।'
+japanese_sentence = '晴れた日です!!!!アンディが戻ってきたら、動物園に行きます。'
+korean_sentence = '화창한 날입니다!!!! Andy가 돌아 오면 우리는 동물원에갑니다.'
+portuguese_sentence = 'É um dia ensolarado!!!! Quando Andy voltar, vamos ao zoológico.'
+russian_sentence = 'Это солнечный день!!!! Когда Энди вернется, мы идем в зоопарк.'
+spanish_sentence = '¡¡¡¡Es un día soleado!!!! Cuando Andy regrese, iremos al zoológico.'
+mixed_sentence = 'It is ä suñny dáy!!!! When Andy comes back, we are going to the 动物园!'
 
 @pytest.mark.parametrize(
-    'expected_len, expected_text, sentence, language',
-    [(0, '', chinese_sentence, 'en'),
-     (2, '今天是个大晴天！', chinese_sentence, 'cn'),
-     (2, 'It is a sunny day again !!!!', mixed_sentence, 'en'),
-     (2, 'It is a sunny day again Ää!!!!', mixed_sentence, 'other')],
+    'expected_len, expected_text, sentence',
+    [(2, 'إنه يوم مشمس!!!!', arabic_sentence),
+     (2, '今天是个大晴天！！！！', chinese_sentence),
+     (2, 'Het is een zonnige dag!!!!', dutch_sentence),
+     (2, "C'est une journée ensoleillée!!!!", french_sentence),
+     (2, 'Es ist ein sonniger Tag!!!!', german_sentence),
+     (2, 'यह एक धूपवाला दिन है!!!!', hindi_sentence),
+     (2, '晴れた日です!!!!', japanese_sentence),
+     (2, '화창한 날입니다!!!!', korean_sentence),
+     (2, 'É um dia ensolarado!!!!', portuguese_sentence),
+     (2, 'Это солнечный день!!!!', russian_sentence),
+     (2, '¡¡¡¡Es un día soleado!!!!', spanish_sentence),
+     (2, 'It is ä suñny dáy!!!!', mixed_sentence)],
 )
-def test_sentencizer_lang(expected_len, expected_text, sentence, language):
+def test_sentencizer_multi_lang(expected_len, expected_text, sentence):
     """
-    Test multiple scenarios with various languages and text
-    When language is set to 'en', filter is applied in segment
-    When language is set to something other than 'en', skip filter
+    Test multiple scenarios with various languages
     """
-    sentencizer = Sentencizer(lang = language)
+    sentencizer = Sentencizer()
     segmented = sentencizer.segment(sentence)
     chunks = [i['text'] for i in segmented]
     assert len(segmented) == expected_len

--- a/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
+++ b/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
@@ -56,34 +56,20 @@ def test_sentencizer_en_trim_spaces():
     with f:
         f.index_lines(['  This ,  text is...  . Amazing !!'], on_done=validate, callback_on_body=True, line_format='csv')
 
-
-arabic_sentence = 'إنه يوم مشمس!!!! عندما يعود آندي ، سنذهب إلى حديقة الحيوانات.'
-chinese_sentence = '今天是个大晴天！！！！安迪回来以后，我们准备去动物园。'
-dutch_sentence = 'Het is een zonnige dag!!!! Als Andy terugkomt, gaan we naar de dierentuin.'
-french_sentence = "C'est une journée ensoleillée!!!! Quand Andy revient, nous allons au zoo."
-german_sentence = 'Es ist ein sonniger Tag!!!! Wenn Andy zurückkommt, gehen wir in den Zoo.'
-hindi_sentence = 'यह एक धूपवाला दिन है!!!! जब एंडी वापस आता है, हम चिड़ियाघर जा रहे हैं।'
-japanese_sentence = '晴れた日です!!!!アンディが戻ってきたら、動物園に行きます。'
-korean_sentence = '화창한 날입니다!!!! Andy가 돌아 오면 우리는 동물원에갑니다.'
-portuguese_sentence = 'É um dia ensolarado!!!! Quando Andy voltar, vamos ao zoológico.'
-russian_sentence = 'Это солнечный день!!!! Когда Энди вернется, мы идем в зоопарк.'
-spanish_sentence = '¡¡¡¡Es un día soleado!!!! Cuando Andy regrese, iremos al zoológico.'
-mixed_sentence = 'It is ä suñny dáy!!!! When Andy comes back, we are going to the 动物园!'
-
 @pytest.mark.parametrize(
     'expected_len, expected_text, sentence',
-    [(2, 'إنه يوم مشمس!!!!', arabic_sentence),
-     (2, '今天是个大晴天！！！！', chinese_sentence),
-     (2, 'Het is een zonnige dag!!!!', dutch_sentence),
-     (2, "C'est une journée ensoleillée!!!!", french_sentence),
-     (2, 'Es ist ein sonniger Tag!!!!', german_sentence),
-     (2, 'यह एक धूपवाला दिन है!!!!', hindi_sentence),
-     (2, '晴れた日です!!!!', japanese_sentence),
-     (2, '화창한 날입니다!!!!', korean_sentence),
-     (2, 'É um dia ensolarado!!!!', portuguese_sentence),
-     (2, 'Это солнечный день!!!!', russian_sentence),
-     (2, '¡¡¡¡Es un día soleado!!!!', spanish_sentence),
-     (2, 'It is ä suñny dáy!!!!', mixed_sentence)],
+    [(2, 'إنه يوم مشمس!!!!', 'إنه يوم مشمس!!!! عندما يعود آندي ، سنذهب إلى حديقة الحيوانات.'),
+     (2, '今天是个大晴天！！！！', '今天是个大晴天！！！！安迪回来以后，我们准备去动物园。'),
+     (2, 'Het is een zonnige dag!!!!', 'Het is een zonnige dag!!!! Als Andy terugkomt, gaan we naar de dierentuin.'),
+     (2, "C'est une journée ensoleillée!!!!", "C'est une journée ensoleillée!!!! Quand Andy revient, nous allons au zoo."),
+     (2, 'Es ist ein sonniger Tag!!!!', 'Es ist ein sonniger Tag!!!! Wenn Andy zurückkommt, gehen wir in den Zoo.'),
+     (2, 'यह एक धूपवाला दिन है!!!!', 'यह एक धूपवाला दिन है!!!! जब एंडी वापस आता है, हम चिड़ियाघर जा रहे हैं।'),
+     (2, '晴れた日です!!!!', '晴れた日です!!!!アンディが戻ってきたら、動物園に行きます。'),
+     (2, '화창한 날입니다!!!!', '화창한 날입니다!!!! Andy가 돌아 오면 우리는 동물원에갑니다.'),
+     (2, 'É um dia ensolarado!!!!', 'É um dia ensolarado!!!! Quando Andy voltar, vamos ao zoológico.'),
+     (2, 'Это солнечный день!!!!', 'Это солнечный день!!!! Когда Энди вернется, мы идем в зоопарк.'),
+     (2, '¡¡¡¡Es un día soleado!!!!', '¡¡¡¡Es un día soleado!!!! Cuando Andy regrese, iremos al zoológico.'),
+     (2, 'It is ä suñny dáy!!!!', 'It is ä suñny dáy!!!! When Andy comes back, we are going to the 动物园!')],
 )
 def test_sentencizer_multi_lang(expected_len, expected_text, sentence):
     """


### PR DESCRIPTION
Address issue https://github.com/jina-ai/jina-hub/issues/5141

Background:
Function `segment` of `Sentencizer` currently doesn't handle text in chinese and many other languages, because the filter uses string.printable, which is limited to english characters.

In this PR:
* Add another input argument to segment indicating which language the input text is, set default value as "en".
* Change segment to only apply filter on english texts.
* Add and update multiple tests for feature validation.

