### PR TITLE
feat: enable Sentencizer to segment text besides English

### DIFF
--- a/segmenters/nlp/Sentencizer/__init__.py
+++ b/segmenters/nlp/Sentencizer/__init__.py
@@ -12,8 +12,7 @@ class Sentencizer(BaseSegmenter):
     The text is split by the punctuation characters listed in ``punct_chars``.
     The sentences that are shorter than the ``min_sent_len``
     or longer than the ``max_sent_len`` after stripping will be discarded.
-    
-    :param lang: language of the input text, by default "en".
+
     :param min_sent_len: the minimal number of characters,
         (including white spaces) of the sentence, by default 1.
     :param max_sent_len: the maximal number of characters,
@@ -29,7 +28,6 @@ class Sentencizer(BaseSegmenter):
     """
 
     def __init__(self,
-                 lang: str = "en",
                  min_sent_len: int = 1,
                  max_sent_len: int = 512,
                  punct_chars: Optional[List[str]] = None,
@@ -37,7 +35,6 @@ class Sentencizer(BaseSegmenter):
                  *args, **kwargs):
         """Set constructor."""
         super().__init__(*args, **kwargs)
-        self.lang = lang
         self.min_sent_len = min_sent_len
         self.max_sent_len = max_sent_len
         self.punct_chars = punct_chars
@@ -66,8 +63,6 @@ class Sentencizer(BaseSegmenter):
         if not ret:
             ret = [(text, 0, len(text))]
         for ci, (r, s, e) in enumerate(ret):
-            # Filter on english characters if lang is set to "en"
-            f = ''.join(filter(lambda x: x in string.printable, r)) if self.lang == 'en' else r
             f = re.sub('\n+', ' ', r).strip()
             f = f[:self.max_sent_len]
             if len(f) > self.min_sent_len:

--- a/segmenters/nlp/Sentencizer/__init__.py
+++ b/segmenters/nlp/Sentencizer/__init__.py
@@ -12,7 +12,8 @@ class Sentencizer(BaseSegmenter):
     The text is split by the punctuation characters listed in ``punct_chars``.
     The sentences that are shorter than the ``min_sent_len``
     or longer than the ``max_sent_len`` after stripping will be discarded.
-
+    
+    :param lang: language of the input text, by default "en".
     :param min_sent_len: the minimal number of characters,
         (including white spaces) of the sentence, by default 1.
     :param max_sent_len: the maximal number of characters,
@@ -28,6 +29,7 @@ class Sentencizer(BaseSegmenter):
     """
 
     def __init__(self,
+                 lang: str = "en",
                  min_sent_len: int = 1,
                  max_sent_len: int = 512,
                  punct_chars: Optional[List[str]] = None,
@@ -35,6 +37,7 @@ class Sentencizer(BaseSegmenter):
                  *args, **kwargs):
         """Set constructor."""
         super().__init__(*args, **kwargs)
+        self.lang = lang
         self.min_sent_len = min_sent_len
         self.max_sent_len = max_sent_len
         self.punct_chars = punct_chars
@@ -63,8 +66,9 @@ class Sentencizer(BaseSegmenter):
         if not ret:
             ret = [(text, 0, len(text))]
         for ci, (r, s, e) in enumerate(ret):
-            f = ''.join(filter(lambda x: x in string.printable, r))
-            f = re.sub('\n+', ' ', f).strip()
+            # Filter on english characters if lang is set to "en"
+            f = ''.join(filter(lambda x: x in string.printable, r)) if self.lang == 'en' else r
+            f = re.sub('\n+', ' ', r).strip()
             f = f[:self.max_sent_len]
             if len(f) > self.min_sent_len:
                 results.append(dict(

--- a/segmenters/nlp/Sentencizer/manifest.yml
+++ b/segmenters/nlp/Sentencizer/manifest.yml
@@ -8,6 +8,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub/blob/master/segmenters/nlp/Sentencizer/README.md
-version: 0.0.10
+version: 0.0.11
 license: apache-2.0
 keywords: [text, nlp, segment]

--- a/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
+++ b/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
@@ -6,7 +6,7 @@ from .. import Sentencizer
 def test_sentencier_en():
     sentencizer = Sentencizer()
     text = 'It is a sunny day!!!! When Andy comes back, we are going to the zoo.'
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 2
 
 
@@ -17,7 +17,7 @@ def test_sentencier_en_new_lines():
     sentencizer = Sentencizer()
     text = 'It is a sunny day!!!! When Andy comes back,\n' \
            'we are going to the zoo.'
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 3
 
 
@@ -29,7 +29,7 @@ def test_sentencier_en_float_numbers():
     sentencizer = Sentencizer()
     text = 'With a 0.99 probability this sentence will be ' \
            'tokenized in 2 sentences.'
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 2
 
 
@@ -41,8 +41,8 @@ def test_sentencier_en_trim_spaces():
     """
     sentencizer = Sentencizer()
     text = '  This ,  text is...  . Amazing !!'
-    chunks = [i['text'] for i in sentencizer.segment(text, 0)]
-    locs = [i['location'] for i in sentencizer.segment(text, 0)]
+    chunks = [i['text'] for i in sentencizer.segment(text)]
+    locs = [i['location'] for i in sentencizer.segment(text)]
     assert chunks, ["This ,  text is..." == "Amazing"]
     assert text[locs[0][0]:locs[0][1]], '  This  ==   text is...'
     assert text[locs[1][0]:locs[1][1]] == ' Amazing'
@@ -56,13 +56,13 @@ def test_sentencier_en_trim_spaces():
         f.index_lines(['  This ,  text is...  . Amazing !!'], on_done=validate, callback_on_body=True, line_format='csv')
 
 
-def test_sentencier_en_filter():
+def test_sentencier_en_emojis():
     """
-    Filter should still work for English
+    Emoji's and non-eng chars in the Proper nouns are no longer filtered
     """
     sentencizer = Sentencizer()
     text = 'It is a sunny day!!!! When müller comes back, we are going to the zoo. 😁'
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 2
 
 
@@ -70,9 +70,9 @@ def test_sentencier_cn():
     """
     Test for chinese
     """
-    sentencizer = Sentencizer(lang='cn')
+    sentencizer = Sentencizer()
     text = '今天是个大晴天！安迪回来以后，我们准备去动物园。'
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 2
 
 
@@ -80,9 +80,9 @@ def test_sentencier_de():
     """
     Test for German
     """
-    sentencizer = Sentencizer(lang='de')
+    sentencizer = Sentencizer()
     text = "Es ist ein sonniger Tag!!!! Wenn Andy zurückkommt, gehen wir in den Zoo."
-    crafted_chunk_list = sentencizer.segment(text, 0)
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 2
 
 
@@ -90,7 +90,7 @@ def test_sentencier_fr():
     """
     Test for French
     """
-    sentencizer = Sentencizer(lang='fr')
+    sentencizer = Sentencizer()
     text = "C'est une journée ensoleillée !!!! Quand Andy revient, nous allons au zoo."
-    crafted_chunk_list = sentencizer.segment(text, 0, lang = 'fr')
+    crafted_chunk_list = sentencizer.segment(text)
     assert len(crafted_chunk_list) == 2

--- a/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
+++ b/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
@@ -56,9 +56,41 @@ def test_sentencier_en_trim_spaces():
         f.index_lines(['  This ,  text is...  . Amazing !!'], on_done=validate, callback_on_body=True, line_format='csv')
 
 
+def test_sentencier_en_filter():
+    """
+    Filter should still work for English
+    """
+    sentencizer = Sentencizer(lang='en')
+    text = 'It is a sunny day!!!! When müller comes back, we are going to the zoo. 😁'
+    crafted_chunk_list = sentencizer.segment(text, 0)
+    assert len(crafted_chunk_list) == 2
+
+
 def test_sentencier_cn():
-    sentencizer = Sentencizer()
+    """
+    Test for chinese
+    """
+    sentencizer = Sentencizer(lang='cn')
     text = '今天是个大晴天！安迪回来以后，我们准备去动物园。'
     crafted_chunk_list = sentencizer.segment(text, 0)
-    # Sentencizer does not work for chinese because string.printable does not contain Chinese characters
-    assert len(crafted_chunk_list) == 0
+    assert len(crafted_chunk_list) == 2
+
+
+def test_sentencier_de():
+    """
+    Test for German
+    """
+    sentencizer = Sentencizer(lang='de')
+    text = "Es ist ein sonniger Tag!!!! Wenn Andy zurückkommt, gehen wir in den Zoo."
+    crafted_chunk_list = sentencizer.segment(text, 0)
+    assert len(crafted_chunk_list) == 2
+
+
+def test_sentencier_fr():
+    """
+    Test for French
+    """
+    sentencizer = Sentencizer(lang='fr')
+    text = "C'est une journée ensoleillée !!!! Quand Andy revient, nous allons au zoo."
+    crafted_chunk_list = sentencizer.segment(text, 0, lang = 'fr')
+    assert len(crafted_chunk_list) == 2

--- a/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
+++ b/segmenters/nlp/Sentencizer/tests/test_sentencizer.py
@@ -60,7 +60,7 @@ def test_sentencier_en_filter():
     """
     Filter should still work for English
     """
-    sentencizer = Sentencizer(lang='en')
+    sentencizer = Sentencizer()
     text = 'It is a sunny day!!!! When müller comes back, we are going to the zoo. 😁'
     crafted_chunk_list = sentencizer.segment(text, 0)
     assert len(crafted_chunk_list) == 2


### PR DESCRIPTION
Fix for issue #5141 

PR Summary:
- Update the santicizer to switch off filter for languages other than english
- Added small test for French and German and fixed the Chinese unit test
- Added test to check for filter in case of non-english characters in english sentence.

Questions:
- How important is the filter on the following line. A potential solution could be to remove the filter altogether:
https://github.com/jina-ai/jina-hub/blob/cb7a176535eed6c86973465e8c6bfc977a4c572e/segmenters/nlp/Sentencizer/__init__.py#L66

Currently, here is no test case that signifies the importance of the filter. A test is added to filter the emoji but I can't think of any significant test case which makes the the filter a must.