### PR TITLE
feat(segmenter): add user dict to JiebaSegmenter

### DIFF
--- a/segmenters/nlp/JiebaSegmenter/__init__.py
+++ b/segmenters/nlp/JiebaSegmenter/__init__.py
@@ -20,7 +20,6 @@ class JiebaSegmenter(BaseSegmenter):
     :type user_dict_file: str
     :raises:
         ValueError: If `mode` is not any of the expected modes
-        FileNotFoundError: If `user_dict_file` does not exist
     :param args:  Additional positional arguments
     :param kwargs: Additional keyword arguments
 
@@ -28,18 +27,22 @@ class JiebaSegmenter(BaseSegmenter):
 
     def __init__(self, mode: str = 'accurate', user_dict_file: str = None, *args, **kwargs):
         """Set Constructor."""
-        import jieba
-        import os
-
         super().__init__(*args, **kwargs)
         if mode not in ('accurate', 'all', 'search'):
             raise ValueError('you must choose one of modes to cut the text: accurate, all, search.')
         self.mode = mode
-
-        if user_dict_file is not None:
-            if not os.path.exists(user_dict_file):
-                raise FileNotFoundError(f'User dictionary can not be found at {user_dict_file}')
         self.user_dict_file = user_dict_file
+
+    def post_init(self):
+        """ Load custom dict if provided. Raise FileNotFoundError if dict does not exist."""
+        super().post_init()
+
+        if self.user_dict_file is not None:
+            import os
+            import jieba
+            if not os.path.exists(self.user_dict_file):
+                raise FileNotFoundError(f'User dictionary can not be found at {self.user_dict_file}')
+            jieba.load_userdict(self.user_dict_file)
 
     def segment(self, text: str, *args, **kwargs) -> List[Dict]:
         """
@@ -53,9 +56,6 @@ class JiebaSegmenter(BaseSegmenter):
         :rtype: List[Dict]
         """
         import jieba
-
-        if self.user_dict_file is not None:
-            jieba.load_userdict(self.user_dict_file)
 
         if self.mode == 'search':
             words = jieba.cut_for_search(text)

--- a/segmenters/nlp/JiebaSegmenter/__init__.py
+++ b/segmenters/nlp/JiebaSegmenter/__init__.py
@@ -56,7 +56,6 @@ class JiebaSegmenter(BaseSegmenter):
         :rtype: List[Dict]
         """
         import jieba
-
         if self.mode == 'search':
             words = jieba.cut_for_search(text)
         elif self.mode == 'all':

--- a/segmenters/nlp/JiebaSegmenter/__init__.py
+++ b/segmenters/nlp/JiebaSegmenter/__init__.py
@@ -14,10 +14,6 @@ class JiebaSegmenter(BaseSegmenter):
      - all
 
     :type mode: str
-    :param pool_size: Number of parallel processes to use.
-        The default is no parallel execution.
-        None will set this value to the number of CPUs.
-    :type pool_size: int
     :param user_dict_file: Path to a custom dictionary.
         This custom dictionary extends the default dictionary.
         `See here for the format of the dict https://github.com/fxsjy/jieba#load-dictionary`_
@@ -30,9 +26,8 @@ class JiebaSegmenter(BaseSegmenter):
 
     """
 
-    def __init__(self, mode: str = 'accurate', pool_size: int = 1, user_dict_file: str = None, *args, **kwargs):
+    def __init__(self, mode: str = 'accurate', user_dict_file: str = None, *args, **kwargs):
         """Set Constructor."""
-        from multiprocessing import cpu_count
         import jieba
         import os
 
@@ -44,12 +39,7 @@ class JiebaSegmenter(BaseSegmenter):
         if user_dict_file is not None:
             if not os.path.exists(user_dict_file):
                 raise FileNotFoundError(f'User dictionary can not be found at {user_dict_file}')
-            jieba.load_userdict(user_dict_file)
-
-        if pool_size is None:
-            jieba.enable_parallel()
-        elif pool_size > 1:
-            jieba.enable_parallel(min(pool_size, cpu_count()))
+        self.user_dict_file = user_dict_file
 
     def segment(self, text: str, *args, **kwargs) -> List[Dict]:
         """
@@ -63,6 +53,10 @@ class JiebaSegmenter(BaseSegmenter):
         :rtype: List[Dict]
         """
         import jieba
+
+        if self.user_dict_file is not None:
+            jieba.load_userdict(self.user_dict_file)
+
         if self.mode == 'search':
             words = jieba.cut_for_search(text)
         elif self.mode == 'all':

--- a/segmenters/nlp/JiebaSegmenter/manifest.yml
+++ b/segmenters/nlp/JiebaSegmenter/manifest.yml
@@ -8,6 +8,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.8
+version: 0.0.9
 license: apache-2.0
 keywords: [jieba, nlp]

--- a/segmenters/nlp/JiebaSegmenter/tests/dict.txt
+++ b/segmenters/nlp/JiebaSegmenter/tests/dict.txt
@@ -1,0 +1,6 @@
+this
+is
+not
+a
+chinese
+word

--- a/segmenters/nlp/JiebaSegmenter/tests/test_jiebasegmenter.py
+++ b/segmenters/nlp/JiebaSegmenter/tests/test_jiebasegmenter.py
@@ -14,28 +14,6 @@ def test_jieba_crafter():
     assert len(crafted_chunk_list) == 14
 
 
-def test_jieba_multi_processing_working():
-    import jieba
-
-    jieba_crafter = JiebaSegmenter(mode='accurate', pool_size=2)
-    text = '今天是个大晴天！安迪回来以后，我们准备去动物园。'
-    crafted_chunk_list = jieba_crafter.segment(text, 0)
-
-    assert jieba.pool is not None
-    assert len(crafted_chunk_list) == 14
-
-
-@pytest.mark.parametrize("pool_size, pool_is_none", [(-1, True), (0, True), (1, True), (2, False), (None, False)])
-def test_jieba_multi_processing_setup(pool_size, pool_is_none):
-    import jieba
-
-    JiebaSegmenter(pool_size=pool_size)
-    if pool_is_none:
-        assert jieba.pool is None
-    else:
-        assert jieba.pool is not None
-
-
 def test_jieba_user_dir():
     jieba_segmenter = JiebaSegmenter()
     text = '今天是个大晴天！安迪回来以后，我们准备去动物园。thisisnotachineseword'

--- a/segmenters/nlp/JiebaSegmenter/tests/test_jiebasegmenter.py
+++ b/segmenters/nlp/JiebaSegmenter/tests/test_jiebasegmenter.py
@@ -10,20 +10,20 @@ path_dict_file = os.path.join(cur_dir, 'dict.txt')
 def test_jieba_crafter():
     jieba_crafter = JiebaSegmenter(mode='accurate')
     text = '今天是个大晴天！安迪回来以后，我们准备去动物园。'
-    crafted_chunk_list = jieba_crafter.segment(text, 0)
+    crafted_chunk_list = jieba_crafter.segment(text)
     assert len(crafted_chunk_list) == 14
 
 
 def test_jieba_user_dir():
     jieba_segmenter = JiebaSegmenter()
     text = '今天是个大晴天！安迪回来以后，我们准备去动物园。thisisnotachineseword'
-    crafted_chunk_list = jieba_segmenter.segment(text, 0)
+    crafted_chunk_list = jieba_segmenter.segment(text)
 
     assert len(crafted_chunk_list) == 15
 
     jieba_segmenter = JiebaSegmenter(user_dict_file=path_dict_file)
     text = '今天是个大晴天！安迪回来以后，我们准备去动物园。thisisnotachineseword'
-    crafted_chunk_list = jieba_segmenter.segment(text, 0)
+    crafted_chunk_list = jieba_segmenter.segment(text)
 
     assert len(crafted_chunk_list) == 20
 

--- a/segmenters/nlp/JiebaSegmenter/tests/test_jiebasegmenter.py
+++ b/segmenters/nlp/JiebaSegmenter/tests/test_jiebasegmenter.py
@@ -1,8 +1,55 @@
+import os
+
+import pytest
+
 from .. import JiebaSegmenter
 
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+path_dict_file = os.path.join(cur_dir, 'dict.txt')
 
 def test_jieba_crafter():
     jieba_crafter = JiebaSegmenter(mode='accurate')
     text = '今天是个大晴天！安迪回来以后，我们准备去动物园。'
     crafted_chunk_list = jieba_crafter.segment(text, 0)
     assert len(crafted_chunk_list) == 14
+
+
+def test_jieba_multi_processing_working():
+    import jieba
+
+    jieba_crafter = JiebaSegmenter(mode='accurate', pool_size=2)
+    text = '今天是个大晴天！安迪回来以后，我们准备去动物园。'
+    crafted_chunk_list = jieba_crafter.segment(text, 0)
+
+    assert jieba.pool is not None
+    assert len(crafted_chunk_list) == 14
+
+
+@pytest.mark.parametrize("pool_size, pool_is_none", [(-1, True), (0, True), (1, True), (2, False), (None, False)])
+def test_jieba_multi_processing_setup(pool_size, pool_is_none):
+    import jieba
+
+    JiebaSegmenter(pool_size=pool_size)
+    if pool_is_none:
+        assert jieba.pool is None
+    else:
+        assert jieba.pool is not None
+
+
+def test_jieba_user_dir():
+    jieba_segmenter = JiebaSegmenter()
+    text = '今天是个大晴天！安迪回来以后，我们准备去动物园。thisisnotachineseword'
+    crafted_chunk_list = jieba_segmenter.segment(text, 0)
+
+    assert len(crafted_chunk_list) == 15
+
+    jieba_segmenter = JiebaSegmenter(user_dict_file=path_dict_file)
+    text = '今天是个大晴天！安迪回来以后，我们准备去动物园。thisisnotachineseword'
+    crafted_chunk_list = jieba_segmenter.segment(text, 0)
+
+    assert len(crafted_chunk_list) == 20
+
+
+def test_jieba_user_dir_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        JiebaSegmenter(user_dict_file='/this/path/does/not/exist.txt')


### PR DESCRIPTION
This PR adds a new option to the `JiebaSegmenter` by exposing an existing feature in the Jieba library:

Allow the user to extend the default dict by a custom dict of their choice. The dict needs to be specified as a path in the `user_dict_file` parameter. The format of the dict is specified in the [Jieba repository](https://github.com/fxsjy/jieba#load-dictionary)

This feature was requested in this [issue](https://github.com/jina-ai/jina-hub/issues/5142), which did not specify exactly which features to expose. 
Potentially one could also expose the functionality to [modify the existing dict](https://github.com/fxsjy/jieba#modify-dictionary). That seemed a bit too cumbersome for the user to me though.
The custom dict feature assumes that the dictionary file is accessible locally. If that requirement is too inconvenient, one could also try to get it via HTTP or so.

All changes are covered with unit tests.