### PR TITLE
fix(bimatch): fix group by order

### DIFF
--- a/rankers/BiMatchRanker/__init__.py
+++ b/rankers/BiMatchRanker/__init__.py
@@ -83,7 +83,7 @@ class BiMatchRanker(Chunk2DocRanker):
         # group by "match_id" or "query_chunk_id". So here groups have in common 1st (match_parent_id) and `n` column
         _groups = self._group_by(g, col)
         # take the best match from each group
-        _groups_best = np.stack([np.sort(gg, order=col)[0] for gg in _groups])
+        _groups_best = np.stack([np.sort(gg, order='score')[0] for gg in _groups])
         # doc total length
         # how many chunks in the document (match or query)
         _c = chunk_meta[_groups_best[0][col]]['length']

--- a/rankers/BiMatchRanker/manifest.yml
+++ b/rankers/BiMatchRanker/manifest.yml
@@ -6,7 +6,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub/blob/master/rankers/BiMatchRanker/README.md
-version: 0.0.12
+version: 0.0.13
 license: apache-2.0
 keywords: [rank, bi-match, naive]
 type: pod

--- a/rankers/BiMatchRanker/tests/test_bimatchranker.py
+++ b/rankers/BiMatchRanker/tests/test_bimatchranker.py
@@ -23,7 +23,7 @@ def test_bimatchranker():
     match_chunk_meta = {'10': {'length': 200}, '11': {'length': 200}, '20': {'length': 300}}
 
     # test score() with fake grouped data
-    match_idx_1 = np.array([('1', '10', '100', 0.40000001), ('1', '10', '110', 0.30000001),
+    match_idx_1 = np.array([('1', '10', '100', 0.4), ('1', '10', '110', 0.3),
                             ('1', '11', '110', 0.2)],
                            dtype=[('match_parent_id', '<U64'), ('match_doc_chunk_id', '<U64'),
                                   ('match_query_chunk_id', '<U64'), ('score', '<f8')])
@@ -68,11 +68,11 @@ def test_bimatchranker_readme():
     match_score_1 = ranker.score(match_idx_1, query_chunk_meta, match_chunk_meta)
     assert match_score_1 == pytest.approx(0.3458, 0.001)
 
-    match_idx_2 = np.array([('2', '21', '1', 0.69999999), ('2', '21', '2', 0.1),
+    match_idx_2 = np.array([('2', '21', '1', 0.7), ('2', '21', '2', 0.1),
                             ('2', '21', '3', 0.1), ('2', '22', '1', 0.5),
-                            ('2', '22', '2', 0.69999999), ('2', '22', '3', 0.5),
-                            ('2', '23', '3', 0.69999999)],
+                            ('2', '22', '2', 0.7), ('2', '22', '3', 0.5),
+                            ('2', '23', '3', 0.7)],
                            dtype=[('match_parent_id', '<U64'), ('match_doc_chunk_id', '<U64'),
                                   ('match_query_chunk_id', '<U64'), ('score', '<f8')])
     match_score_2 = ranker.score(match_idx_2, query_chunk_meta, match_chunk_meta)
-    assert match_score_2 == pytest.approx(0.5333, 0.001)
+    assert match_score_2 == pytest.approx(0.6666, 0.001)


### PR DESCRIPTION
`_groups_best = np.stack([np.sort(gg, order=col)[0] for gg in _groups])`
should sort by 'score' to get the best, this won't have effect if we use default d_miss value since it has a large value. 