### PR TITLE
chore: version bump to test issues with hub database

### DIFF
--- a/crafters/numeric/ArrayStringReader/manifest.yml
+++ b/crafters/numeric/ArrayStringReader/manifest.yml
@@ -7,6 +7,6 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub/blob/master/crafters/numeric/ArrayStringReader/README.md
-version: 0.0.10
+version: 0.0.11
 license: apache-2.0
 keywords: [crafter, numeric, string]


### PR DESCRIPTION
We released a new jina version that catches errors and fails with hubapi related exceptions. This is a PR that I want to merge to verify the hubapi invocations during CD. 