### PR TITLE
feat: added huggingface api calls

### DIFF
--- a/encoders/nlp/TransformerTorchEncoder/README.md
+++ b/encoders/nlp/TransformerTorchEncoder/README.md
@@ -1,3 +1,17 @@
 # TransformerTorchEncoder
 
-TransformerTorchEncoder wraps the pytorch-version of transformers from huggingface, encodes data from an array of string in size `B` into an ndarray in size `B x D` 
+TransformerTorchEncoder wraps the pytorch-version of transformers from huggingface, encodes data from an array of string in size `B` into an ndarray in size `B x D`
+
+## Using the huggingface [API](https://api-inference.huggingface.co/docs/python/html/index.html)
+
+It is also possible to directly call the huggingface API instead of running the model yourself.
+The only change needed in the code is adding an `api_token`, e.g.
+
+```
+!TransformerTorchEncoder
+with:
+  pooling_strategy: auto
+  pretrained_model_name_or_path: distilbert-base-cased
+  max_length: 192
+  api_token: api_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```

--- a/encoders/nlp/TransformerTorchEncoder/__init__.py
+++ b/encoders/nlp/TransformerTorchEncoder/__init__.py
@@ -143,11 +143,11 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
         import requests
 
         retries = 0
+        headers = {"Authorization": "Bearer " + self.api_token}
+        api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{self.pretrained_model_name_or_path}"
 
         while retries < self.max_retries:
             retries += 1
-            headers = {"Authorization": "Bearer " + self.api_token}
-            api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{self.pretrained_model_name_or_path}"
             r = requests.post(api_url, json=query, headers=headers)
             if r.status_code == HTTP_SERVICE_UNAVAILABLE:
                 self.logger.info('Service is currently unavailable. Model is loading.')

--- a/encoders/nlp/TransformerTorchEncoder/__init__.py
+++ b/encoders/nlp/TransformerTorchEncoder/__init__.py
@@ -237,7 +237,4 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
                         return outputs.cpu().numpy()
                     hidden_states = outputs.hidden_states
 
-            if not isinstance(outputs, torch.Tensor):
-                return self._compute_embedding(hidden_states, input_tokens)
-            else:
-                return outputs.cpu().numpy()
+            return self._compute_embedding(hidden_states, input_tokens)

--- a/encoders/nlp/TransformerTorchEncoder/__init__.py
+++ b/encoders/nlp/TransformerTorchEncoder/__init__.py
@@ -6,14 +6,12 @@ import time
 from typing import Optional, Dict
 
 import numpy as np
-import requests
 
 from jina.executors.decorators import batching, as_ndarray
 from jina.executors.devices import TorchDevice
 from jina.executors.encoders import BaseEncoder
 
 if False:
-    # It is not assumed yet they inherit from this, but the transformers documentation seem to suggest so
     import torch
 
 HTTP_SERVICE_UNAVAILABLE = 503
@@ -128,6 +126,8 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
                 self.model = torch.quantization.quantize_dynamic(
                     self.model, {torch.nn.Linear}, dtype=torch.qint8
                 )
+        else:
+            self._api_call('Scotty, please warmup.')
 
     def amp_accelerate(self):
         """Check acceleration method """
@@ -140,6 +140,8 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
             return nullcontext()
 
     def _api_call(self, query):
+        import requests
+
         retries = 0
 
         while retries < self.max_retries:

--- a/encoders/nlp/TransformerTorchEncoder/__init__.py
+++ b/encoders/nlp/TransformerTorchEncoder/__init__.py
@@ -1,10 +1,12 @@
 __copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-import os
+import time
+
 from typing import Optional, Dict
 
 import numpy as np
+import requests
 
 from jina.executors.decorators import batching, as_ndarray
 from jina.executors.devices import TorchDevice
@@ -12,7 +14,9 @@ from jina.executors.encoders import BaseEncoder
 
 if False:
     # It is not assumed yet they inherit from this, but the transformers documentation seem to suggest so
-    from transformers.modeling_outputs import BaseModelOutput
+    import torch
+
+HTTP_SERVICE_UNAVAILABLE = 503
 
 
 class TransformerTorchEncoder(TorchDevice, BaseEncoder):
@@ -53,25 +57,31 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
     """
 
     def __init__(
-            self,
-            pretrained_model_name_or_path: str = 'sentence-transformers/distilbert-base-nli-stsb-mean-tokens',
-            base_tokenizer_model: Optional[str] = None,
-            pooling_strategy: str = 'mean',
-            layer_index: int = -1,
-            max_length: Optional[int] = None,
-            acceleration: Optional[str] = None,
-            embedding_fn_name: str = '__call__',
-            *args,
-            **kwargs,
+        self,
+        pretrained_model_name_or_path: str = 'sentence-transformers/distilbert-base-nli-stsb-mean-tokens',
+        base_tokenizer_model: Optional[str] = None,
+        pooling_strategy: str = 'mean',
+        layer_index: int = -1,
+        max_length: Optional[int] = None,
+        acceleration: Optional[str] = None,
+        embedding_fn_name: str = '__call__',
+        api_token: Optional[str] = None,
+        max_retries: int = 20,
+        *args,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.pretrained_model_name_or_path = pretrained_model_name_or_path
-        self.base_tokenizer_model = base_tokenizer_model or pretrained_model_name_or_path
+        self.base_tokenizer_model = (
+            base_tokenizer_model or pretrained_model_name_or_path
+        )
         self.pooling_strategy = pooling_strategy
         self.layer_index = layer_index
         self.max_length = max_length
         self.acceleration = acceleration
         self.embedding_fn_name = embedding_fn_name
+        self.api_token = api_token
+        self.max_retries = max_retries
 
         if self.pooling_strategy == 'auto':
             self.pooling_strategy = 'cls'
@@ -94,21 +104,30 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
             )
             raise NotImplementedError
 
+        if self.api_token is not None and self.layer_index != -1:
+            self.logger.error(
+                f'layer_index {self.layer_index} not available via the huggingface API.'
+                ' Please set the layer_index to -1 or disable huggingface API usage.'
+            )
+            raise ValueError
+
     def post_init(self):
         """Load the transformer model and encoder"""
         import torch
         from transformers import AutoModel, AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(self.base_tokenizer_model)
-        self.model = AutoModel.from_pretrained(
-            self.pretrained_model_name_or_path, output_hidden_states=True
-        )
-        self.to_device(self.model)
 
-        if self.acceleration == 'quant' and not self.on_gpu:
-            self.model = torch.quantization.quantize_dynamic(
-                self.model, {torch.nn.Linear}, dtype=torch.qint8
+        if self.api_token is None:
+            self.model = AutoModel.from_pretrained(
+                self.pretrained_model_name_or_path, output_hidden_states=True
             )
+            self.to_device(self.model)
+
+            if self.acceleration == 'quant' and not self.on_gpu:
+                self.model = torch.quantization.quantize_dynamic(
+                    self.model, {torch.nn.Linear}, dtype=torch.qint8
+                )
 
     def amp_accelerate(self):
         """Check acceleration method """
@@ -120,9 +139,25 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
         else:
             return nullcontext()
 
-    def _compute_embedding_from_model_output(self, outputs: 'BaseModelOutput', input_tokens: Dict):
+    def _api_call(self, query):
+        retries = 0
+
+        while retries < self.max_retries:
+            retries += 1
+            headers = {"Authorization": "Bearer " + self.api_token}
+            api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{self.pretrained_model_name_or_path}"
+            r = requests.post(api_url, json=query, headers=headers)
+            if r.status_code == HTTP_SERVICE_UNAVAILABLE:
+                self.logger.info('Service is currently unavailable. Model is loading.')
+                time.sleep(3)
+            else:
+                break
+        return r.json()
+
+    def _compute_embedding(self, hidden_states: 'torch.Tensor', input_tokens: Dict):
         import torch
-        n_layers = len(outputs.hidden_states)
+
+        n_layers = len(hidden_states)
         if self.layer_index not in list(range(-n_layers, n_layers)):
             self.logger.error(
                 f'Invalid value {self.layer_index} for `layer_index`,'
@@ -142,7 +177,7 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
         fill_vals = {'cls': 0.0, 'mean': 0.0, 'max': -np.inf, 'min': np.inf}
         fill_val = torch.tensor(fill_vals[self.pooling_strategy], device=self.device)
 
-        layer = outputs.hidden_states[self.layer_index]
+        layer = hidden_states[self.layer_index]
         attn_mask = input_tokens['attention_mask'].unsqueeze(-1).expand_as(layer)
         layer = torch.where(attn_mask.bool(), layer, fill_val)
 
@@ -159,7 +194,6 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
             embeddings = layer.min(dim=1).values
 
         return embeddings.cpu().numpy()
-
 
     @batching
     @as_ndarray
@@ -188,10 +222,20 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
             )
             input_tokens = {k: v.to(self.device) for k, v in input_tokens.items()}
 
-            with self.amp_accelerate():
-                outputs = getattr(self.model, self.embedding_fn_name)(**input_tokens)
+            if self.api_token is not None:
+                outputs = self._api_call(list(data))
+
+                hidden_states = torch.tensor([outputs])
+            else:
+                with self.amp_accelerate():
+                    outputs = getattr(self.model, self.embedding_fn_name)(
+                        **input_tokens
+                    )
+                    if isinstance(outputs, torch.Tensor):
+                        return outputs.cpu().numpy()
+                    hidden_states = outputs.hidden_states
 
             if not isinstance(outputs, torch.Tensor):
-                return self._compute_embedding_from_model_output(outputs, input_tokens)
+                return self._compute_embedding(hidden_states, input_tokens)
             else:
                 return outputs.cpu().numpy()

--- a/encoders/nlp/TransformerTorchEncoder/__init__.py
+++ b/encoders/nlp/TransformerTorchEncoder/__init__.py
@@ -143,7 +143,7 @@ class TransformerTorchEncoder(TorchDevice, BaseEncoder):
         import requests
 
         retries = 0
-        headers = {"Authorization": "Bearer " + self.api_token}
+        headers = {"Authorization": f"Bearer {self.api_token}"}
         api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{self.pretrained_model_name_or_path}"
 
         while retries < self.max_retries:

--- a/encoders/nlp/TransformerTorchEncoder/manifest.yml
+++ b/encoders/nlp/TransformerTorchEncoder/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.25
+version: 0.0.26
 license: apache-2.0
 keywords: [huggingface, transformers, nlp, BERT, pytorch]
 type: pod

--- a/encoders/nlp/TransformerTorchEncoder/requirements.txt
+++ b/encoders/nlp/TransformerTorchEncoder/requirements.txt
@@ -1,1 +1,2 @@
 jina==1.1.0
+requests

--- a/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
+++ b/encoders/nlp/TransformerTorchEncoder/tests/test_transformertorchencoder.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -35,13 +36,12 @@ def _assert_params_equal(params_dict: dict, encoder: TransformerTorchEncoder):
 @pytest.mark.parametrize('pooling_strategy', ['cls', 'mean', 'max'])
 @pytest.mark.parametrize('layer_index', [-1, -2, 0])
 def test_encoding_results(test_metas, model_name, pooling_strategy, layer_index):
-    params = {
-        'pretrained_model_name_or_path': model_name,
-        'pooling_strategy': pooling_strategy,
-        'layer_index': layer_index,
-    }
-
-    encoder = TransformerTorchEncoder(metas=test_metas, **params)
+    encoder = TransformerTorchEncoder(
+        metas=test_metas,
+        pretrained_model_name_or_path=model_name,
+        pooling_strategy=pooling_strategy,
+        layer_index=layer_index,
+    )
 
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
     encoded_data = encoder.encode(test_data)
@@ -64,14 +64,11 @@ def test_encoding_results(test_metas, model_name, pooling_strategy, layer_index)
 
 @pytest.mark.parametrize('function_name', ['embed_questions', 'embed_answers'])
 def test_encoding_results_retribert(test_metas, function_name):
-    model_name = 'yjernite/retribert-base-uncased'
-
-    params = {
-        'pretrained_model_name_or_path': model_name,
-        'embedding_fn_name': function_name,
-    }
-
-    encoder = TransformerTorchEncoder(metas=test_metas, **params)
+    encoder = TransformerTorchEncoder(
+        metas=test_metas,
+        pretrained_model_name_or_path='yjernite/retribert-base-uncased',
+        embedding_fn_name=function_name,
+    )
 
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
     encoded_data = encoder.encode(test_data)
@@ -86,9 +83,7 @@ def test_encoding_results_acceleration(test_metas, acceleration):
     if 'JINA_TEST_GPU' in os.environ and acceleration == 'quant':
         pytest.skip("Can't test quantization on GPU.")
 
-    encoder = TransformerTorchEncoder(
-        metas=test_metas, **{"acceleration": acceleration}
-    )
+    encoder = TransformerTorchEncoder(metas=test_metas, acceleration=acceleration)
 
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
     encoded_data = encoder.encode(test_data)
@@ -101,14 +96,14 @@ def test_encoding_results_acceleration(test_metas, acceleration):
 @pytest.mark.parametrize('pooling_strategy', ['cls', 'mean', 'max'])
 @pytest.mark.parametrize('layer_index', [-1, -2])
 def test_embedding_consistency(test_metas, model_name, pooling_strategy, layer_index):
-    params = {
-        'pretrained_model_name_or_path': model_name,
-        'pooling_strategy': pooling_strategy,
-        'layer_index': layer_index,
-    }
-    test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
+    encoder = TransformerTorchEncoder(
+        metas=test_metas,
+        pretrained_model_name_or_path=model_name,
+        pooling_strategy=pooling_strategy,
+        layer_index=layer_index,
+    )
 
-    encoder = TransformerTorchEncoder(metas=test_metas, **params)
+    test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
     encoded_data = encoder.encode(test_data)
 
     encoded_data_file = f'tests/{model_name}-{pooling_strategy}-{layer_index}.npy'
@@ -121,13 +116,14 @@ def test_embedding_consistency(test_metas, model_name, pooling_strategy, layer_i
 @pytest.mark.parametrize('pooling_strategy', ['cls', 'mean', 'max'])
 @pytest.mark.parametrize('layer_index', [-1])
 def test_max_length_truncation(test_metas, model_name, pooling_strategy, layer_index):
-    params = {
-        'pretrained_model_name_or_path': model_name,
-        'pooling_strategy': pooling_strategy,
-        'layer_index': layer_index,
-        'max_length': 3,
-    }
-    encoder = TransformerTorchEncoder(metas=test_metas, **params)
+    encoder = TransformerTorchEncoder(
+        metas=test_metas,
+        pretrained_model_name_or_path=model_name,
+        pooling_strategy=pooling_strategy,
+        layer_index=layer_index,
+        max_length=3,
+    )
+
     test_data = np.array(['it is a very good day!', 'it is a very sunny day!'])
     encoded_data = encoder.encode(test_data)
 
@@ -138,15 +134,17 @@ def test_max_length_truncation(test_metas, model_name, pooling_strategy, layer_i
 @pytest.mark.parametrize('pooling_strategy', ['cls', 'mean', 'max'])
 @pytest.mark.parametrize('layer_index', [-1, -2])
 def test_shape_single_document(test_metas, model_name, pooling_strategy, layer_index):
-    params = {
-        'pretrained_model_name_or_path': model_name,
-        'pooling_strategy': pooling_strategy,
-        'layer_index': layer_index,
-        'max_length': 3,
-    }
-    encoder = TransformerTorchEncoder(metas=test_metas, **params)
+    encoder = TransformerTorchEncoder(
+        metas=test_metas,
+        pretrained_model_name_or_path=model_name,
+        pooling_strategy=pooling_strategy,
+        layer_index=layer_index,
+        max_length=3,
+    )
+
     test_data = np.array(['it is a very good day!'])
     encoded_data = encoder.encode(test_data)
+
     assert len(encoded_data.shape) == 2
     assert encoded_data.shape[0] == 1
 
@@ -160,7 +158,12 @@ def test_save_and_load(test_metas, model_name, pooling_strategy, layer_index):
         'pooling_strategy': pooling_strategy,
         'layer_index': layer_index,
     }
-    encoder = TransformerTorchEncoder(metas=test_metas, **params)
+    encoder = TransformerTorchEncoder(
+        metas=test_metas,
+        pretrained_model_name_or_path=model_name,
+        pooling_strategy=pooling_strategy,
+        layer_index=layer_index,
+    )
     test_data = np.array(['a', 'b', 'c', 'x', '!'])
     encoded_data_control = encoder.encode(test_data)
 
@@ -196,11 +199,10 @@ def test_save_and_load_config(test_metas, model_name, pooling_strategy, layer_in
 
 @pytest.mark.parametrize('layer_index', [-100, 100])
 def test_wrong_layer_index(test_metas, layer_index):
-    params = {'layer_index': layer_index}
-    encoder = TransformerTorchEncoder(metas=test_metas, **params)
+    encoder = TransformerTorchEncoder(metas=test_metas, layer_index=layer_index)
 
-    encoder.layer_index = layer_index
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
+
     with pytest.raises(ValueError):
         _ = encoder.encode(test_data)
 
@@ -224,3 +226,24 @@ def test_no_cls_token(test_metas, params):
     test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
     with pytest.raises(ValueError):
         _ = encoder.encode(test_data)
+
+
+@pytest.mark.parametrize('pooling_strategy', ['cls', 'mean', 'max'])
+def test_encoding_results_api(test_metas, pooling_strategy):
+    encoder = TransformerTorchEncoder(
+        metas=test_metas,
+        pretrained_model_name_or_path='sentence-transformers/distilbert-base-nli-stsb-mean-tokens',
+        pooling_strategy=pooling_strategy,
+        api_token='fake_token',
+    )
+
+    api_mock = MagicMock(return_value=np.random.rand(2, 9, 768).tolist())
+    encoder._api_call = api_mock
+
+    test_data = np.array(['it is a good day!', 'the dog sits on the floor.'])
+    encoded_data = encoder.encode(test_data)
+
+    api_mock.assert_called()
+    assert encoded_data.shape == (2, 768)
+
+    assert not np.allclose(encoded_data[0], encoded_data[1], rtol=1)


### PR DESCRIPTION
Enables the usage of the huggingface API instead of calling a model locally. To enable it, just add an API token to the encoder. The model will not be loaded locally at all.

```
!TransformerTorchEncoder
with:
  pooling_strategy: auto
  pretrained_model_name_or_path: distilbert-base-cased
  max_length: 192
  api_token: ${{JINA_HUGGINGFACE_API_TOKEN}}
```