### PR TITLE
feat: add truncated SVD encoder

### DIFF
--- a/encoders/numeric/TruncatedSVDEncoder/Dockerfile
+++ b/encoders/numeric/TruncatedSVDEncoder/Dockerfile
@@ -1,4 +1,4 @@
-FROM jinaai/jina
+FROM jinaai/jina as base
 
 # setup the workspace
 COPY . /workspace
@@ -8,6 +8,8 @@ WORKDIR /workspace
 RUN pip install -r requirements.txt
 
 # for testing the image
+FROM base
 RUN pip install pytest && pytest
 
+FROM base
 ENTRYPOINT ["jina", "pod", "--uses", "config.yml"]

--- a/encoders/numeric/TruncatedSVDEncoder/Dockerfile
+++ b/encoders/numeric/TruncatedSVDEncoder/Dockerfile
@@ -1,0 +1,13 @@
+FROM jinaai/jina
+
+# setup the workspace
+COPY . /workspace
+WORKDIR /workspace
+
+# install the third-party requirements
+RUN pip install -r requirements.txt
+
+# for testing the image
+RUN pip install pytest && pytest
+
+ENTRYPOINT ["jina", "pod", "--uses", "config.yml"]

--- a/encoders/numeric/TruncatedSVDEncoder/README.md
+++ b/encoders/numeric/TruncatedSVDEncoder/README.md
@@ -1,0 +1,13 @@
+# TruncatedSVDEncoder
+
+`TruncatedSVDEncoder` encodes data from an `ndarray` of size `BatchSize x Dimension` into an `ndarray` of size `BatchSize x EmbeddingDimension` using [Truncated Singular Value Decomposition (SVD)](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html).  Truncated SVD is a dimension reduction technique which does not center the data before computation which makes it efficient for sparse matrices.
+
+## Usage:
+
+Initialise the encoder using the parameters mentioned below:
+
+| `param name`    | `param_remarks`                              |
+| --------------- | ---------------------------------------------|
+| `output_dim`    | dimensionality of output embedding           |
+| `algorithm`     | algorithm to be used to run SVD              |
+| `max_iter`      | number of iterations for the algorithm to run|

--- a/encoders/numeric/TruncatedSVDEncoder/README.md
+++ b/encoders/numeric/TruncatedSVDEncoder/README.md
@@ -1,13 +1,16 @@
 # TruncatedSVDEncoder
 
-`TruncatedSVDEncoder` encodes data from an `ndarray` of size `BatchSize x Dimension` into an `ndarray` of size `BatchSize x EmbeddingDimension` using [Truncated Singular Value Decomposition (SVD)](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html).  Truncated SVD is a dimension reduction technique which does not center the data before computation which makes it efficient for sparse matrices.
+`TruncatedSVDEncoder` encodes data from an `ndarray` of size `BatchSize x Dimension` into an `ndarray` of size `BatchSize x EmbeddingDimension` using [Truncated Singular Value Decomposition (SVD)](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html).
+
+Truncated SVD is a dimensionality reduction technique which does not center the data before computation. This makes them useful on large input sparse data which cannot be centered without constraining the memory.
+
 
 ## Usage:
 
 Initialise the encoder using the parameters mentioned below:
 
-| `param name`    | `param_remarks`                              |
-| --------------- | ---------------------------------------------|
-| `output_dim`    | dimensionality of output embedding           |
-| `algorithm`     | algorithm to be used to run SVD              |
-| `max_iter`      | number of iterations for the algorithm to run|
+| `param name`    | `param_remarks`                                           |
+| --------------- | ----------------------------------------------------------|
+| `output_dim`    | dimensionality of output embedding                        |
+| `algorithm`     | algorithm to be used to run SVD (`arpack` or `randomized`)|
+| `max_iter`      | number of iterations for the algorithm to run             |

--- a/encoders/numeric/TruncatedSVDEncoder/README.md
+++ b/encoders/numeric/TruncatedSVDEncoder/README.md
@@ -5,7 +5,7 @@
 Truncated SVD is a dimensionality reduction technique which does not center the data before computation. This makes them useful on large input sparse data which cannot be centered without constraining the memory.
 
 
-## Usage:
+## Initialization:
 
 Initialise the encoder using the parameters mentioned below:
 
@@ -14,3 +14,39 @@ Initialise the encoder using the parameters mentioned below:
 | `output_dim`    | dimensionality of output embedding                        |
 | `algorithm`     | algorithm to be used to run SVD (`arpack` or `randomized`)|
 | `max_iter`      | number of iterations for the algorithm to run             |
+
+## Usage
+
+Users can use Pod images in several ways:
+
+1. Run with docker:
+
+```
+docker run jinahub/pod.encoder.truncatedsvdencoder:MODULE_VERSION-JINA_VERSION
+```
+
+2. Run the Flow API:
+
+```
+ from jina.flow import Flow
+
+ f = (Flow()
+     .add(name='truncated_svd_encoder', uses='docker://jinahub/pod.encoder.truncatedsvdencoder:MODULE_VERSION-JINA_VERSION', port_in=55555, port_out=55556))
+```
+
+3. Run with Jina CLI
+
+```
+ jina pod --uses docker://jinahub/pod.encoder.truncatedsvdencoder:MODULE_VERSION-JINA_VERSION --port-in 55555 --port-out 55556
+```
+
+4. Conventional local usage with `uses` argument
+
+```
+jina pod --uses custom_folder/truncatedsvdencoder.yml --port-in 55555 --port-out 55556
+```
+
+**NOTE**:
+
+- `MODULE_VERSION` is the version of the TruncatedSVDEncoder, in semver format. E.g. `0.0.1` and can be found in the `manifest.yml` file.
+- `JINA_VERSION` is the version of the Jina core version with which the Docker image was built. E.g. `1.1.2`

--- a/encoders/numeric/TruncatedSVDEncoder/__init__.py
+++ b/encoders/numeric/TruncatedSVDEncoder/__init__.py
@@ -38,16 +38,13 @@ class TruncatedSVDEncoder(TransformEncoder):
         self.max_iter = max_iter
         self.algorithm = algorithm
         self.is_trained = False
-        self.model = None
 
     def post_init(self):
         """Load TruncatedSVD model"""
         super().post_init()
-        if not self.model:
-            from sklearn.decomposition import TruncatedSVD
 
-            self.model = TruncatedSVD(
-                n_components=self.output_dim,
-                algorithm=self.algorithm,
-                n_iter=self.max_iter,
-            )
+        from sklearn.decomposition import TruncatedSVD
+
+        self.model = TruncatedSVD(
+            n_components=self.output_dim, algorithm=self.algorithm, n_iter=self.max_iter
+        )

--- a/encoders/numeric/TruncatedSVDEncoder/__init__.py
+++ b/encoders/numeric/TruncatedSVDEncoder/__init__.py
@@ -2,6 +2,7 @@ __copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 from jina.executors.encoders.numeric import TransformEncoder
+from jina.executors.decorators import batching, require_train
 
 
 class TruncatedSVDEncoder(TransformEncoder):
@@ -48,3 +49,17 @@ class TruncatedSVDEncoder(TransformEncoder):
         self.model = TruncatedSVD(
             n_components=self.output_dim, algorithm=self.algorithm, n_iter=self.max_iter
         )
+
+    @require_train
+    @batching
+    def encode(self, data, *args, **kwargs) -> "np.ndarray":
+        """
+        Encode data from an ndarray in size `B x T` into an ndarray
+        in size `B x D`.
+
+        :param data: a `B x T` ndarray
+        :return: a `B x D` numpy ndarray
+        :param args:  Additional positional arguments
+        :param kwargs: Additional keyword arguments
+        """
+        return super().encode(data, *args, **kwargs)

--- a/encoders/numeric/TruncatedSVDEncoder/__init__.py
+++ b/encoders/numeric/TruncatedSVDEncoder/__init__.py
@@ -8,14 +8,15 @@ from jina.executors.decorators import batching, require_train
 class TruncatedSVDEncoder(TransformEncoder):
     """
     Encodes data using truncated SVD, and does not center the data before
-    computing SVD which makes it efficient when working with sparse matrices.
+    computing SVD hence making them efficient for sparse input matrices.
 
     Encodes data from a ndarray of size `B x T` into a ndarray of size `B x D`.
     Where `B` is the batch's size and `T` and `D` are the dimensions pre (`T`)
     and after (`D`) the encoding.
 
     :param output_dim: Dimension of the output embedded space
-    :param n_iter: Number of iterations for the encoder to run
+    :param algorithm: algorithm to be used to run SVD
+    :param max_iter: Number of iterations for the encoder to run
     :param args:  Additional positional arguments
     :param kwargs: Additional keyword arguments
 

--- a/encoders/numeric/TruncatedSVDEncoder/__init__.py
+++ b/encoders/numeric/TruncatedSVDEncoder/__init__.py
@@ -1,0 +1,53 @@
+__copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
+__license__ = "Apache-2.0"
+
+from jina.executors.encoders.numeric import TransformEncoder
+
+
+class TruncatedSVDEncoder(TransformEncoder):
+    """
+    Encodes data using truncated SVD, and does not center the data before
+    computing SVD which makes it efficient when working with sparse matrices.
+
+    Encodes data from a ndarray of size `B x T` into a ndarray of size `B x D`.
+    Where `B` is the batch's size and `T` and `D` are the dimensions pre (`T`)
+    and after (`D`) the encoding.
+
+    :param output_dim: Dimension of the output embedded space
+    :param n_iter: Number of iterations for the encoder to run
+    :param args:  Additional positional arguments
+    :param kwargs: Additional keyword arguments
+
+    More details can be found
+    `here <https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html>`_
+
+    .. note::
+        :class:`TruncatedSVDEncoder` must be trained before calling ``encode()``.
+    """
+
+    def __init__(
+        self,
+        output_dim: int = None,
+        algorithm: str = "randomized",
+        max_iter: int = 200,
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.output_dim = output_dim
+        self.max_iter = max_iter
+        self.algorithm = algorithm
+        self.is_trained = False
+        self.model = None
+
+    def post_init(self):
+        """Load TruncatedSVD model"""
+        super().post_init()
+        if not self.model:
+            from sklearn.decomposition import TruncatedSVD
+
+            self.model = TruncatedSVD(
+                n_components=self.output_dim,
+                algorithm=self.algorithm,
+                n_iter=self.max_iter,
+            )

--- a/encoders/numeric/TruncatedSVDEncoder/__init__.py
+++ b/encoders/numeric/TruncatedSVDEncoder/__init__.py
@@ -29,7 +29,7 @@ class TruncatedSVDEncoder(TransformEncoder):
 
     def __init__(
         self,
-        output_dim: int = None,
+        output_dim: int = 20,
         algorithm: str = "randomized",
         max_iter: int = 200,
         *args,

--- a/encoders/numeric/TruncatedSVDEncoder/config.yml
+++ b/encoders/numeric/TruncatedSVDEncoder/config.yml
@@ -1,0 +1,7 @@
+!TruncatedSVDEncoder
+with:
+  {}
+metas:
+  py_modules:
+    # - you can put more dependencies here
+    - __init__.py

--- a/encoders/numeric/TruncatedSVDEncoder/manifest.yml
+++ b/encoders/numeric/TruncatedSVDEncoder/manifest.yml
@@ -2,7 +2,7 @@ manifest_version: 1
 name: TruncatedSVDEncoder
 kind: encoder
 description: |
-  :class:`TruncatedSVDEncoder` encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`.
+  `TruncatedSVDEncoder` is a dimensionality reduction technique using SVD and encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`. More documentation can be found here: https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html.
 author: Harshdeep Singh (harshdeep.harshdeep@epfl.ch)
 url: https://jina.ai
 vendor: Jina AI Limited

--- a/encoders/numeric/TruncatedSVDEncoder/manifest.yml
+++ b/encoders/numeric/TruncatedSVDEncoder/manifest.yml
@@ -1,0 +1,13 @@
+manifest_version: 1
+name: TruncatedSVDEncoder
+kind: encoder
+description: |
+  :class:`TruncatedSVDEncoder` encodes data from an ndarray in size `B x T` into an ndarray in size `B x D`.
+author: Harshdeep Singh (harshdeep.harshdeep@epfl.ch)
+url: https://jina.ai
+vendor: Jina AI Limited
+documentation: https://github.com/jina-ai/jina-hub
+version: 0.0.1
+license: apache-2.0
+keywords: [sklearn, decomposition, TruncatedSVD, svd, encoder, numeric]
+type: pod

--- a/encoders/numeric/TruncatedSVDEncoder/requirements.txt
+++ b/encoders/numeric/TruncatedSVDEncoder/requirements.txt
@@ -1,0 +1,1 @@
+scikit-learn==0.24.0

--- a/encoders/numeric/TruncatedSVDEncoder/tests/test_truncatedsvdencoder.py
+++ b/encoders/numeric/TruncatedSVDEncoder/tests/test_truncatedsvdencoder.py
@@ -1,0 +1,77 @@
+import os
+import pytest
+import pickle
+import shutil
+
+import numpy as np
+
+from .. import TruncatedSVDEncoder
+from jina.executors import BaseExecutor
+from jina.executors.encoders.numeric import TransformEncoder
+
+tmp_model_filename = "truncated_svd.model"
+
+
+def get_encoder(train_data, target_output_dim):
+    from sklearn.decomposition import TruncatedSVD
+
+    model = TruncatedSVD(n_components=target_output_dim)
+    pickle.dump(model.fit(train_data), open(tmp_model_filename, "wb"))
+    return TransformEncoder(model_path=tmp_model_filename)
+
+
+@pytest.fixture(scope="function")
+def train_data():
+    """
+    Create an array of the given shape and populate it with random
+    samples from a uniform distribution over [0, 1).
+
+    :return: a `B x T` numpy ``ndarray``, `B` is the size of the batch
+    """
+    batch_size = 2000
+    input_dim = 28
+    train_data = np.random.rand(batch_size, input_dim)
+
+    return train_data
+
+
+@pytest.fixture(scope="function")
+def test_data():
+    """
+    Create an array of the given shape and populate it with random
+    samples from a uniform distribution over [0, 1).
+
+    :return: a `B x T` numpy ``ndarray``, `B` is the size of the batch
+    """
+    batch_size = 10
+    input_dim = 28
+    test_data = np.random.rand(batch_size, input_dim)
+
+    return test_data
+
+
+@pytest.mark.parametrize("target_output_dim", [2])
+def test_truncated_svd_encoder_train(train_data, test_data, target_output_dim):
+    encoder = TruncatedSVDEncoder(output_dim=target_output_dim)
+    encoder.train(train_data)
+    encoded_data = encoder.encode(test_data)
+
+    assert encoded_data.shape == (test_data.shape[0], target_output_dim)
+    assert type(encoded_data) == np.ndarray
+
+
+@pytest.mark.parametrize("target_output_dim", [2])
+def test_truncated_svd_save_and_load(train_data, test_data, target_output_dim):
+    encoder = get_encoder(train_data, target_output_dim)
+    encoded_data_orig = encoder.encode(test_data)
+
+    encoder.touch()
+    encoder.save()
+    assert os.path.exists(encoder.save_abspath)
+
+    encoder_loaded = BaseExecutor.load(encoder.save_abspath)
+    encoded_data_test = encoder_loaded.encode(test_data)
+    np.testing.assert_array_equal(encoded_data_test, encoded_data_orig)
+
+    shutil.rmtree(f"{encoder.workspace_name}-0")
+    os.remove(tmp_model_filename)

--- a/encoders/numeric/TruncatedSVDEncoder/tests/test_truncatedsvdencoder.py
+++ b/encoders/numeric/TruncatedSVDEncoder/tests/test_truncatedsvdencoder.py
@@ -63,6 +63,7 @@ def test_truncated_svd_encoder_train(train_data, test_data, target_output_dim):
 @pytest.mark.parametrize("target_output_dim", [2])
 def test_truncated_svd_save_and_load(train_data, test_data, target_output_dim):
     encoder = get_encoder(train_data, target_output_dim)
+    assert encoder is not None
     encoded_data_orig = encoder.encode(test_data)
 
     encoder.touch()


### PR DESCRIPTION
This pull request adds a [Truncated Singular Value Decomposition (SVD)](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html) encoder from the Scikit-Learn library.

The truncated SVD dimensionality reduction algorithm does not center the data before the computation of SVD (and hence does not constrain the memory for large datasets) which makes it efficient for working with sparse (input) matrices.