### PR TITLE
fix: check path to vectorizer exists

### DIFF
--- a/encoders/nlp/TFIDFTextEncoder/__init__.py
+++ b/encoders/nlp/TFIDFTextEncoder/__init__.py
@@ -1,23 +1,30 @@
 __copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from jina.executors.encoders import BaseEncoder
+import os
 import numpy as np
+
+from jina.executors.encoders import BaseEncoder
+from jina.excepts import PretrainedModelFileDoesNotExist
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 class TFIDFTextEncoder(BaseEncoder):
     """Encode ``Document`` content from a `np.ndarray` (of strings) of length `BatchSize` into
-    a `csr_matrix` of shape `Batchsize x EmbeddingDimension`. 
+    a `csr_matrix` of shape `Batchsize x EmbeddingDimension`.
 
     :param path_vectorizer: path containing the fitted tfidf encoder object
     :param args: not used
     :param kwargs: not used
     """
 
-    def __init__(self,
-                 path_vectorizer="./model/tfidf_vectorizer.pickle",
-                 *args,
-                 **kwargs):
+    def __init__(
+        self,
+        path_vectorizer: str = os.path.join(cur_dir, 'model/tfidf_vectorizer.pickle'),
+        *args,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self.path_vectorizer = path_vectorizer
 
@@ -27,7 +34,11 @@ class TFIDFTextEncoder(BaseEncoder):
 
         super().post_init()
         if os.path.exists(self.path_vectorizer):
-            self.tfidf_vectorizer = pickle.load(open(self.path_vectorizer, "rb"))
+            self.tfidf_vectorizer = pickle.load(open(self.path_vectorizer, 'rb'))
+        else:
+            raise PretrainedModelFileDoesNotExist(
+                f'{self.path_vectorizer} not found, cannot find a fitted tfidf_vectorizer'
+            )
 
     def encode(self, content: np.ndarray, *args, **kwargs) -> 'scipy.sparse.csr_matrix':
         """Encode the ``Document`` content creating a tf-idf feature vector of the input.

--- a/encoders/nlp/TFIDFTextEncoder/manifest.yml
+++ b/encoders/nlp/TFIDFTextEncoder/manifest.yml
@@ -7,7 +7,7 @@ description: |
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub
-version: 0.0.3
+version: 0.0.4
 license: apache-2.0
 keywords: [nlp, text retrieval]
 type: pod

--- a/encoders/nlp/TFIDFTextEncoder/tests/test_tfidftextencoder.py
+++ b/encoders/nlp/TFIDFTextEncoder/tests/test_tfidftextencoder.py
@@ -1,8 +1,11 @@
 import os
-import scipy
 
 import numpy as np
+import scipy
+import pytest
+
 from .. import TFIDFTextEncoder
+from jina.excepts import PretrainedModelFileDoesNotExist
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -14,18 +17,26 @@ def print_array_info(x, x_varname):
     print(f'{x_varname}.shape={x.shape}')
 
 
+def test_missing_path_vectorizer():
+    wrong_path_vectorizer = os.path.join(
+        cur_dir, '/model/tfidf_nonexistent_path.pickle'
+    )
+    with pytest.raises(PretrainedModelFileDoesNotExist):
+        encoder = TFIDFTextEncoder(wrong_path_vectorizer)
+
+
 def test_tfidf_text_encoder():
     # Input
     text = np.array(['Han likes eating pizza'])
 
-    # Encoder embedding 
+    # Encoder embedding
     encoder = TFIDFTextEncoder()
 
     print_array_info(text, 'text')
     embeddeding = encoder.encode(text)
     print_array_info(embeddeding, 'embeddeding')
 
-    # Compare with ouptut 
+    # Compare with ouptut
     expected = scipy.sparse.load_npz(os.path.join(cur_dir, 'expected.npz'))
     np.testing.assert_almost_equal(embeddeding.todense(), expected.todense(), decimal=4)
     assert expected.shape[0] == len(text)
@@ -50,21 +61,25 @@ def test_tfidf_unexistant_words():
 
     # Compare with ouptut
     np.testing.assert_almost_equal(embedding_1.todense(), expected_1, decimal=4)
-    np.testing.assert_almost_equal(embedding_2.todense(), expected_2.todense(), decimal=4)
+    np.testing.assert_almost_equal(
+        embedding_2.todense(), expected_2.todense(), decimal=4
+    )
 
 
 def test_tfidf_text_encoder_batch():
     # Input
     text_batch = np.array(['Han likes eating pizza', 'Han likes pizza', 'Jina rocks'])
 
-    # Encoder embedding 
+    # Encoder embedding
     encoder = TFIDFTextEncoder()
 
     print_array_info(text_batch, 'text_batch')
     embeddeding_batch = encoder.encode(text_batch)
     print_array_info(embeddeding_batch, 'embeddeding_batch')
 
-    # Compare with ouptut 
+    # Compare with ouptut
     expected_batch = scipy.sparse.load_npz(os.path.join(cur_dir, 'expected_batch.npz'))
-    np.testing.assert_almost_equal(embeddeding_batch.todense(), expected_batch.todense(), decimal=2)
+    np.testing.assert_almost_equal(
+        embeddeding_batch.todense(), expected_batch.todense(), decimal=2
+    )
     assert expected_batch.shape[0] == len(text_batch)


### PR DESCRIPTION
The encoder could 'silently break' if the path to the trained vectorizer did not exist. This PR fixes this.