### PR TITLE
fix: sorting properly casting strings to floats

### DIFF
--- a/indexers/vector/PysparnnIndexer/__init__.py
+++ b/indexers/vector/PysparnnIndexer/__init__.py
@@ -158,7 +158,7 @@ class PysparnnIndexer(BaseVectorIndexer):
         distances = []
         indices = []
         for record in index_distance_pairs:
-            sorted_record = sorted(record, key=lambda x: float(x[0]),reverse=False)
+            sorted_record = sorted(record, key=lambda x: float(x[0]), reverse=False)
             distance_list, index_list = zip(*sorted_record)
             distances.append(distance_list)
             indices.append(index_list)

--- a/indexers/vector/PysparnnIndexer/__init__.py
+++ b/indexers/vector/PysparnnIndexer/__init__.py
@@ -158,6 +158,7 @@ class PysparnnIndexer(BaseVectorIndexer):
         distances = []
         indices = []
         for record in index_distance_pairs:
+            sorted_record = sorted(record, key=lambda x: float(x[0]),reverse=False)
             distance_list, index_list = zip(*record)
             distances.append(distance_list)
             indices.append(index_list)

--- a/indexers/vector/PysparnnIndexer/__init__.py
+++ b/indexers/vector/PysparnnIndexer/__init__.py
@@ -159,7 +159,7 @@ class PysparnnIndexer(BaseVectorIndexer):
         indices = []
         for record in index_distance_pairs:
             sorted_record = sorted(record, key=lambda x: float(x[0]),reverse=False)
-            distance_list, index_list = zip(*record)
+            distance_list, index_list = zip(*sorted_record)
             distances.append(distance_list)
             indices.append(index_list)
         return np.array(indices), np.array(distances).astype(np.float)

--- a/indexers/vector/PysparnnIndexer/manifest.yml
+++ b/indexers/vector/PysparnnIndexer/manifest.yml
@@ -7,7 +7,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub/blob/master/indexers/vector/PysparnnIndexer/README.md
-version: 0.0.5
+version: 0.0.6
 license: apache-2.0
 keywords: [indexer, vector, Sparse, Approximate Search]
 


### PR DESCRIPTION
Pysparnn does not behave as expected when there distances are strings [as shown here.](https://github.com/facebookresearch/pysparnn/issues/35) This PR fixes the issue casting them into floats and sorting the results. 