### PR TITLE
feat: add batching query capability to mongodbindexer

### DIFF
--- a/indexers/keyvalue/MongoDBIndexer/__init__.py
+++ b/indexers/keyvalue/MongoDBIndexer/__init__.py
@@ -94,8 +94,7 @@ class MongoDBIndexer(BinaryPbIndexer):
             for key in keys:
                 result.append(mongo_handler.query(key))
 
-        if result:
-            return result
+        return result
 
     def update(self, keys: Iterable[str], values: Iterable[bytes], *args, **kwargs) -> None:
         """Update the document at the given key in the database.

--- a/indexers/keyvalue/MongoDBIndexer/__init__.py
+++ b/indexers/keyvalue/MongoDBIndexer/__init__.py
@@ -83,14 +83,16 @@ class MongoDBIndexer(BinaryPbIndexer):
         """Get the handler to MongoDB."""
         return self.get_query_handler()
 
-    def query(self, key: str, *args, **kwargs) -> Optional[bytes]:
+    def query(self, keys: Iterable[str], *args, **kwargs) -> Optional[bytes]:
         """Query the serialized documents by document id.
 
         :param key: document id
         :return: serialized document
         """
+        result = []
         with self.query_handler as mongo_handler:
-            result = mongo_handler.query(key)
+            for key in keys:
+                result.append(mongo_handler.query(key))
 
         if result:
             return result

--- a/indexers/keyvalue/MongoDBIndexer/manifest.yml
+++ b/indexers/keyvalue/MongoDBIndexer/manifest.yml
@@ -6,7 +6,7 @@ author: Jina AI Dev-Team (dev-team@jina.ai)
 url: https://jina.ai
 vendor: Jina AI Limited
 documentation: https://github.com/jina-ai/jina-hub/blob/master/indexers/keyvalue/MongoDBIndexer/README.md
-version: 0.0.8
+version: 0.0.9
 license: apache-2.0
 keywords: [keyvalue, database, mongo, indexer, nosql]
 type: pod

--- a/indexers/keyvalue/MongoDBIndexer/tests/test_mongodbindexer.py
+++ b/indexers/keyvalue/MongoDBIndexer/tests/test_mongodbindexer.py
@@ -43,7 +43,8 @@ def test_mongodbindexer():
         mongo_indexer.add(keys=keys, values=values)
 
     with MongoDBIndexer() as mongo_query:
-        result = mongo_query.query(key=query_key)
+        results = mongo_query.query(keys=[query_key])
+        result = results[0]
         assert result['_id'] == query_key
         d = Document()
         d.ParseFromString(result['values'])
@@ -60,8 +61,10 @@ def test_mongodbindexer():
         mongo_indexer.update(keys=keys, values=new_values)
 
     with MongoDBIndexer() as mongo_query:
-        for key, new_value in zip(keys, new_texts):
-            result = mongo_query.query(key)
+        results = [mongo_query.query([key]) for key in keys]
+
+        for key, new_value, result in zip(keys, new_texts, results):
+            result = result[0]
             assert result['_id'] == key
             new_doc = Document()
             new_doc.ParseFromString(result['values'])
@@ -73,5 +76,5 @@ def test_mongodbindexer():
 
     with MongoDBIndexer() as mongo_query:
         for key in keys:
-            result = mongo_query.query(key)
-            assert result is None
+            result = mongo_query.query([key])
+            assert result == [None]

--- a/indexers/keyvalue/MongoDBIndexer/tests/test_mongodbindexer.py
+++ b/indexers/keyvalue/MongoDBIndexer/tests/test_mongodbindexer.py
@@ -61,10 +61,9 @@ def test_mongodbindexer():
         mongo_indexer.update(keys=keys, values=new_values)
 
     with MongoDBIndexer() as mongo_query:
-        results = [mongo_query.query([key]) for key in keys]
+        results = mongo_query.query(keys)
 
         for key, new_value, result in zip(keys, new_texts, results):
-            result = result[0]
             assert result['_id'] == key
             new_doc = Document()
             new_doc.ParseFromString(result['values'])

--- a/indexers/keyvalue/MongoDBIndexer/tests/test_mongodbindexer.py
+++ b/indexers/keyvalue/MongoDBIndexer/tests/test_mongodbindexer.py
@@ -74,6 +74,4 @@ def test_mongodbindexer():
         mongo_query.delete(keys)
 
     with MongoDBIndexer() as mongo_query:
-        for key in keys:
-            result = mongo_query.query([key])
-            assert result == [None]
+        assert mongo_query.query(keys) == [None] * len(keys)


### PR DESCRIPTION
This PR allows query to work on `keys:Iterable[str]`